### PR TITLE
Add Settings Override Support and Recon Commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+.vscode/

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,7 +2,7 @@
 name = "appdirs"
 version = "1.4.4"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -29,10 +29,37 @@ python2 = ["typed-ast (>=1.4.2)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
+name = "cachetools"
+version = "4.2.2"
+description = "Extensible memoizing collections and decorators"
+category = "main"
+optional = false
+python-versions = "~=3.5"
+
+[[package]]
+name = "certifi"
+version = "2021.5.30"
+description = "Python package for providing Mozilla's CA Bundle."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "charset-normalizer"
+version = "2.0.4"
+description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
+category = "main"
+optional = false
+python-versions = ">=3.5.0"
+
+[package.extras]
+unicode_backport = ["unicodedata2"]
+
+[[package]]
 name = "click"
 version = "8.0.1"
 description = "Composable command line interface toolkit"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -43,17 +70,118 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 name = "colorama"
 version = "0.4.4"
 description = "Cross-platform colored terminal text."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "google-auth"
+version = "1.34.0"
+description = "Google Authentication Library"
+category = "main"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*"
+
+[package.dependencies]
+cachetools = ">=2.0.0,<5.0"
+pyasn1-modules = ">=0.2.1"
+rsa = {version = ">=3.1.4,<5", markers = "python_version >= \"3.6\""}
+six = ">=1.9.0"
+
+[package.extras]
+aiohttp = ["requests (>=2.20.0,<3.0.0dev)", "aiohttp (>=3.6.2,<4.0.0dev)"]
+pyopenssl = ["pyopenssl (>=20.0.0)"]
+reauth = ["pyu2f (>=0.1.5)"]
+
+[[package]]
+name = "idna"
+version = "3.2"
+description = "Internationalized Domain Names in Applications (IDNA)"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
+name = "jinja2"
+version = "3.0.1"
+description = "A very fast and expressive template engine."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+MarkupSafe = ">=2.0"
+
+[package.extras]
+i18n = ["Babel (>=2.7)"]
+
+[[package]]
+name = "kubernetes"
+version = "17.17.0"
+description = "Kubernetes python client"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+certifi = ">=14.05.14"
+google-auth = ">=1.0.1"
+python-dateutil = ">=2.5.3"
+pyyaml = ">=3.12"
+requests = "*"
+requests-oauthlib = "*"
+six = ">=1.9.0"
+urllib3 = ">=1.24.2"
+websocket-client = ">=0.32.0,<0.40.0 || >0.40.0,<0.41.0 || >=0.43.0"
+
+[package.extras]
+adal = ["adal (>=1.0.2)"]
+
+[[package]]
+name = "markupsafe"
+version = "2.0.1"
+description = "Safely add untrusted strings to HTML/XML markup."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "mypy"
+version = "0.910"
+description = "Optional static typing for Python"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+mypy-extensions = ">=0.4.3,<0.5.0"
+toml = "*"
+typing-extensions = ">=3.7.4"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+python2 = ["typed-ast (>=1.4.0,<1.5.0)"]
 
 [[package]]
 name = "mypy-extensions"
 version = "0.4.3"
 description = "Experimental type system extensions for programs checked with the mypy typechecker."
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "oauthlib"
+version = "3.1.1"
+description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+rsa = ["cryptography (>=3.0.0,<4)"]
+signals = ["blinker (>=1.4.0)"]
+signedtoken = ["cryptography (>=3.0.0,<4)", "pyjwt (>=2.0.0,<3)"]
 
 [[package]]
 name = "pathspec"
@@ -64,12 +192,118 @@ optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [[package]]
+name = "pyasn1"
+version = "0.4.8"
+description = "ASN.1 types and codecs"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.2.8"
+description = "A collection of ASN.1-based protocols modules."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pyasn1 = ">=0.4.6,<0.5.0"
+
+[[package]]
+name = "pycryptodome"
+version = "3.10.1"
+description = "Cryptographic library for Python"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "python-dateutil"
+version = "2.8.2"
+description = "Extensions to the standard Python datetime module"
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
+name = "pyyaml"
+version = "5.4.1"
+description = "YAML parser and emitter for Python"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+
+[[package]]
 name = "regex"
 version = "2021.8.3"
 description = "Alternative regular expression module, to replace re."
 category = "dev"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "requests"
+version = "2.26.0"
+description = "Python HTTP for Humans."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+charset-normalizer = {version = ">=2.0.0,<2.1.0", markers = "python_version >= \"3\""}
+idna = {version = ">=2.5,<4", markers = "python_version >= \"3\""}
+urllib3 = ">=1.21.1,<1.27"
+
+[package.extras]
+socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
+
+[[package]]
+name = "requests-oauthlib"
+version = "1.3.0"
+description = "OAuthlib authentication support for Requests."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.dependencies]
+oauthlib = ">=3.0.0"
+requests = ">=2.0.0"
+
+[package.extras]
+rsa = ["oauthlib[signedtoken] (>=3.0.0)"]
+
+[[package]]
+name = "rsa"
+version = "4.7.2"
+description = "Pure-Python RSA implementation"
+category = "main"
+optional = false
+python-versions = ">=3.5, <4"
+
+[package.dependencies]
+pyasn1 = ">=0.1.3"
+
+[[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "toml"
+version = "0.10.2"
+description = "Python Library for Tom's Obvious, Minimal Language"
+category = "main"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "tomli"
@@ -79,10 +313,56 @@ category = "dev"
 optional = false
 python-versions = ">=3.6"
 
+[[package]]
+name = "tutor"
+version = "12.0.4"
+description = "The Docker-based Open edX distribution designed for peace of mind"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+appdirs = "*"
+click = ">=7.0"
+jinja2 = "*"
+kubernetes = "*"
+mypy = "*"
+pycryptodome = "*"
+pyyaml = ">=4.2b1"
+
+[[package]]
+name = "typing-extensions"
+version = "3.10.0.0"
+description = "Backported and Experimental Type Hints for Python 3.5+"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "urllib3"
+version = "1.26.6"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+
+[package.extras]
+brotli = ["brotlipy (>=0.6.0)"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+
+[[package]]
+name = "websocket-client"
+version = "1.2.0"
+description = "WebSocket client for Python with low level API options"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "7c01f3f1bbf59bfa659694ce5da59221a2e3d0827f3ea389ff20e3b7967a3eb7"
+content-hash = "f2e75e2fe63089fc3b5bb4158bc08e8d9c21379fcdc0de477a98877282b0c839"
 
 [metadata.files]
 appdirs = [
@@ -93,6 +373,18 @@ black = [
     {file = "black-21.7b0-py3-none-any.whl", hash = "sha256:1c7aa6ada8ee864db745b22790a32f94b2795c253a75d6d9b5e439ff10d23116"},
     {file = "black-21.7b0.tar.gz", hash = "sha256:c8373c6491de9362e39271630b65b964607bc5c79c83783547d76c839b3aa219"},
 ]
+cachetools = [
+    {file = "cachetools-4.2.2-py3-none-any.whl", hash = "sha256:2cc0b89715337ab6dbba85b5b50effe2b0c74e035d83ee8ed637cf52f12ae001"},
+    {file = "cachetools-4.2.2.tar.gz", hash = "sha256:61b5ed1e22a0924aed1d23b478f37e8d52549ff8a961de2909c69bf950020cff"},
+]
+certifi = [
+    {file = "certifi-2021.5.30-py2.py3-none-any.whl", hash = "sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8"},
+    {file = "certifi-2021.5.30.tar.gz", hash = "sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee"},
+]
+charset-normalizer = [
+    {file = "charset-normalizer-2.0.4.tar.gz", hash = "sha256:f23667ebe1084be45f6ae0538e4a5a865206544097e4e8bbcacf42cd02a348f3"},
+    {file = "charset_normalizer-2.0.4-py3-none-any.whl", hash = "sha256:0c8911edd15d19223366a194a513099a302055a962bca2cec0f54b8b63175d8b"},
+]
 click = [
     {file = "click-8.0.1-py3-none-any.whl", hash = "sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6"},
     {file = "click-8.0.1.tar.gz", hash = "sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a"},
@@ -101,13 +393,211 @@ colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
+google-auth = [
+    {file = "google-auth-1.34.0.tar.gz", hash = "sha256:f1094088bae046fb06f3d1a3d7df14717e8d959e9105b79c57725bd4e17597a2"},
+    {file = "google_auth-1.34.0-py2.py3-none-any.whl", hash = "sha256:bd6aa5916970a823e76ffb3d5c3ad3f0bedafca0a7fa53bc15149ab21cb71e05"},
+]
+idna = [
+    {file = "idna-3.2-py3-none-any.whl", hash = "sha256:14475042e284991034cb48e06f6851428fb14c4dc953acd9be9a5e95c7b6dd7a"},
+    {file = "idna-3.2.tar.gz", hash = "sha256:467fbad99067910785144ce333826c71fb0e63a425657295239737f7ecd125f3"},
+]
+jinja2 = [
+    {file = "Jinja2-3.0.1-py3-none-any.whl", hash = "sha256:1f06f2da51e7b56b8f238affdd6b4e2c61e39598a378cc49345bc1bd42a978a4"},
+    {file = "Jinja2-3.0.1.tar.gz", hash = "sha256:703f484b47a6af502e743c9122595cc812b0271f661722403114f71a79d0f5a4"},
+]
+kubernetes = [
+    {file = "kubernetes-17.17.0-py3-none-any.whl", hash = "sha256:225a95a0aadbd5b645ab389d941a7980db8cdad2a776fde64d1b43fc3299bde9"},
+    {file = "kubernetes-17.17.0.tar.gz", hash = "sha256:c69b318696ba797dcf63eb928a8d4370c52319f4140023c502d7dfdf2080eb79"},
+]
+markupsafe = [
+    {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:36bc903cbb393720fad60fc28c10de6acf10dc6cc883f3e24ee4012371399a38"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:add36cb2dbb8b736611303cd3bfcee00afd96471b09cda130da3581cbdc56a6d"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-win32.whl", hash = "sha256:99df47edb6bda1249d3e80fdabb1dab8c08ef3975f69aed437cb69d0a5de1e28"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:e0f138900af21926a02425cf736db95be9f4af72ba1bb21453432a07f6082134"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf5d821ffabf0ef3533c39c518f3357b171a1651c1ff6827325e4489b0e46c3c"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0d4b31cc67ab36e3392bbf3862cfbadac3db12bdd8b02a2731f509ed5b829724"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:baa1a4e8f868845af802979fcdbf0bb11f94f1cb7ced4c4b8a351bb60d108145"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-win32.whl", hash = "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:6557b31b5e2c9ddf0de32a691f2312a32f77cd7681d8af66c2692efdbef84c18"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:49e3ceeabbfb9d66c3aef5af3a60cc43b85c33df25ce03d0031a608b0a8b2e3f"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e9936f0b261d4df76ad22f8fee3ae83b60d7c3e871292cd42f40b81b70afae85"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:2a7d351cbd8cfeb19ca00de495e224dea7e7d919659c2841bbb7f420ad03e2d6"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:60bf42e36abfaf9aff1f50f52644b336d4f0a3fd6d8a60ca0d054ac9f713a864"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-win32.whl", hash = "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:5bb28c636d87e840583ee3adeb78172efc47c8b26127267f54a9c0ec251d41a9"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6fcf051089389abe060c9cd7caa212c707e58153afa2c649f00346ce6d260f1b"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5855f8438a7d1d458206a2466bf82b0f104a3724bf96a1c781ab731e4201731a"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3dd007d54ee88b46be476e293f48c85048603f5f516008bee124ddd891398ed6"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-win32.whl", hash = "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3c112550557578c26af18a1ccc9e090bfe03832ae994343cfdacd287db6a6ae7"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:53edb4da6925ad13c07b6d26c2a852bd81e364f95301c66e930ab2aef5b5ddd8"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:f5653a225f31e113b152e56f154ccbe59eeb1c7487b39b9d9f9cdb58e6c79dc5"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c47adbc92fc1bb2b3274c4b3a43ae0e4573d9fbff4f54cd484555edbf030baf1"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:37205cac2a79194e3750b0af2a5720d95f786a55ce7df90c3af697bfa100eaac"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1f2ade76b9903f39aa442b4aadd2177decb66525062db244b35d71d0ee8599b6"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-win32.whl", hash = "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8"},
+    {file = "MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"},
+]
+mypy = [
+    {file = "mypy-0.910-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:a155d80ea6cee511a3694b108c4494a39f42de11ee4e61e72bc424c490e46457"},
+    {file = "mypy-0.910-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:b94e4b785e304a04ea0828759172a15add27088520dc7e49ceade7834275bedb"},
+    {file = "mypy-0.910-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:088cd9c7904b4ad80bec811053272986611b84221835e079be5bcad029e79dd9"},
+    {file = "mypy-0.910-cp35-cp35m-win_amd64.whl", hash = "sha256:adaeee09bfde366d2c13fe6093a7df5df83c9a2ba98638c7d76b010694db760e"},
+    {file = "mypy-0.910-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:ecd2c3fe726758037234c93df7e98deb257fd15c24c9180dacf1ef829da5f921"},
+    {file = "mypy-0.910-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:d9dd839eb0dc1bbe866a288ba3c1afc33a202015d2ad83b31e875b5905a079b6"},
+    {file = "mypy-0.910-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:3e382b29f8e0ccf19a2df2b29a167591245df90c0b5a2542249873b5c1d78212"},
+    {file = "mypy-0.910-cp36-cp36m-win_amd64.whl", hash = "sha256:53fd2eb27a8ee2892614370896956af2ff61254c275aaee4c230ae771cadd885"},
+    {file = "mypy-0.910-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b6fb13123aeef4a3abbcfd7e71773ff3ff1526a7d3dc538f3929a49b42be03f0"},
+    {file = "mypy-0.910-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e4dab234478e3bd3ce83bac4193b2ecd9cf94e720ddd95ce69840273bf44f6de"},
+    {file = "mypy-0.910-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:7df1ead20c81371ccd6091fa3e2878559b5c4d4caadaf1a484cf88d93ca06703"},
+    {file = "mypy-0.910-cp37-cp37m-win_amd64.whl", hash = "sha256:0aadfb2d3935988ec3815952e44058a3100499f5be5b28c34ac9d79f002a4a9a"},
+    {file = "mypy-0.910-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ec4e0cd079db280b6bdabdc807047ff3e199f334050db5cbb91ba3e959a67504"},
+    {file = "mypy-0.910-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:119bed3832d961f3a880787bf621634ba042cb8dc850a7429f643508eeac97b9"},
+    {file = "mypy-0.910-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:866c41f28cee548475f146aa4d39a51cf3b6a84246969f3759cb3e9c742fc072"},
+    {file = "mypy-0.910-cp38-cp38-win_amd64.whl", hash = "sha256:ceb6e0a6e27fb364fb3853389607cf7eb3a126ad335790fa1e14ed02fba50811"},
+    {file = "mypy-0.910-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1a85e280d4d217150ce8cb1a6dddffd14e753a4e0c3cf90baabb32cefa41b59e"},
+    {file = "mypy-0.910-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:42c266ced41b65ed40a282c575705325fa7991af370036d3f134518336636f5b"},
+    {file = "mypy-0.910-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:3c4b8ca36877fc75339253721f69603a9c7fdb5d4d5a95a1a1b899d8b86a4de2"},
+    {file = "mypy-0.910-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:c0df2d30ed496a08de5daed2a9ea807d07c21ae0ab23acf541ab88c24b26ab97"},
+    {file = "mypy-0.910-cp39-cp39-win_amd64.whl", hash = "sha256:c6c2602dffb74867498f86e6129fd52a2770c48b7cd3ece77ada4fa38f94eba8"},
+    {file = "mypy-0.910-py3-none-any.whl", hash = "sha256:ef565033fa5a958e62796867b1df10c40263ea9ded87164d67572834e57a174d"},
+    {file = "mypy-0.910.tar.gz", hash = "sha256:704098302473cb31a218f1775a873b376b30b4c18229421e9e9dc8916fd16150"},
+]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
+oauthlib = [
+    {file = "oauthlib-3.1.1-py2.py3-none-any.whl", hash = "sha256:42bf6354c2ed8c6acb54d971fce6f88193d97297e18602a3a886603f9d7730cc"},
+    {file = "oauthlib-3.1.1.tar.gz", hash = "sha256:8f0215fcc533dd8dd1bee6f4c412d4f0cd7297307d43ac61666389e3bc3198a3"},
+]
 pathspec = [
     {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
     {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
+]
+pyasn1 = [
+    {file = "pyasn1-0.4.8-py2.4.egg", hash = "sha256:fec3e9d8e36808a28efb59b489e4528c10ad0f480e57dcc32b4de5c9d8c9fdf3"},
+    {file = "pyasn1-0.4.8-py2.5.egg", hash = "sha256:0458773cfe65b153891ac249bcf1b5f8f320b7c2ce462151f8fa74de8934becf"},
+    {file = "pyasn1-0.4.8-py2.6.egg", hash = "sha256:5c9414dcfede6e441f7e8f81b43b34e834731003427e5b09e4e00e3172a10f00"},
+    {file = "pyasn1-0.4.8-py2.7.egg", hash = "sha256:6e7545f1a61025a4e58bb336952c5061697da694db1cae97b116e9c46abcf7c8"},
+    {file = "pyasn1-0.4.8-py2.py3-none-any.whl", hash = "sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d"},
+    {file = "pyasn1-0.4.8-py3.1.egg", hash = "sha256:78fa6da68ed2727915c4767bb386ab32cdba863caa7dbe473eaae45f9959da86"},
+    {file = "pyasn1-0.4.8-py3.2.egg", hash = "sha256:08c3c53b75eaa48d71cf8c710312316392ed40899cb34710d092e96745a358b7"},
+    {file = "pyasn1-0.4.8-py3.3.egg", hash = "sha256:03840c999ba71680a131cfaee6fab142e1ed9bbd9c693e285cc6aca0d555e576"},
+    {file = "pyasn1-0.4.8-py3.4.egg", hash = "sha256:7ab8a544af125fb704feadb008c99a88805126fb525280b2270bb25cc1d78a12"},
+    {file = "pyasn1-0.4.8-py3.5.egg", hash = "sha256:e89bf84b5437b532b0803ba5c9a5e054d21fec423a89952a74f87fa2c9b7bce2"},
+    {file = "pyasn1-0.4.8-py3.6.egg", hash = "sha256:014c0e9976956a08139dc0712ae195324a75e142284d5f87f1a87ee1b068a359"},
+    {file = "pyasn1-0.4.8-py3.7.egg", hash = "sha256:99fcc3c8d804d1bc6d9a099921e39d827026409a58f2a720dcdb89374ea0c776"},
+    {file = "pyasn1-0.4.8.tar.gz", hash = "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba"},
+]
+pyasn1-modules = [
+    {file = "pyasn1-modules-0.2.8.tar.gz", hash = "sha256:905f84c712230b2c592c19470d3ca8d552de726050d1d1716282a1f6146be65e"},
+    {file = "pyasn1_modules-0.2.8-py2.4.egg", hash = "sha256:0fe1b68d1e486a1ed5473f1302bd991c1611d319bba158e98b106ff86e1d7199"},
+    {file = "pyasn1_modules-0.2.8-py2.5.egg", hash = "sha256:fe0644d9ab041506b62782e92b06b8c68cca799e1a9636ec398675459e031405"},
+    {file = "pyasn1_modules-0.2.8-py2.6.egg", hash = "sha256:a99324196732f53093a84c4369c996713eb8c89d360a496b599fb1a9c47fc3eb"},
+    {file = "pyasn1_modules-0.2.8-py2.7.egg", hash = "sha256:0845a5582f6a02bb3e1bde9ecfc4bfcae6ec3210dd270522fee602365430c3f8"},
+    {file = "pyasn1_modules-0.2.8-py2.py3-none-any.whl", hash = "sha256:a50b808ffeb97cb3601dd25981f6b016cbb3d31fbf57a8b8a87428e6158d0c74"},
+    {file = "pyasn1_modules-0.2.8-py3.1.egg", hash = "sha256:f39edd8c4ecaa4556e989147ebf219227e2cd2e8a43c7e7fcb1f1c18c5fd6a3d"},
+    {file = "pyasn1_modules-0.2.8-py3.2.egg", hash = "sha256:b80486a6c77252ea3a3e9b1e360bc9cf28eaac41263d173c032581ad2f20fe45"},
+    {file = "pyasn1_modules-0.2.8-py3.3.egg", hash = "sha256:65cebbaffc913f4fe9e4808735c95ea22d7a7775646ab690518c056784bc21b4"},
+    {file = "pyasn1_modules-0.2.8-py3.4.egg", hash = "sha256:15b7c67fabc7fc240d87fb9aabf999cf82311a6d6fb2c70d00d3d0604878c811"},
+    {file = "pyasn1_modules-0.2.8-py3.5.egg", hash = "sha256:426edb7a5e8879f1ec54a1864f16b882c2837bfd06eee62f2c982315ee2473ed"},
+    {file = "pyasn1_modules-0.2.8-py3.6.egg", hash = "sha256:cbac4bc38d117f2a49aeedec4407d23e8866ea4ac27ff2cf7fb3e5b570df19e0"},
+    {file = "pyasn1_modules-0.2.8-py3.7.egg", hash = "sha256:c29a5e5cc7a3f05926aff34e097e84f8589cd790ce0ed41b67aed6857b26aafd"},
+]
+pycryptodome = [
+    {file = "pycryptodome-3.10.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:1c5e1ca507de2ad93474be5cfe2bfa76b7cf039a1a32fc196f40935944871a06"},
+    {file = "pycryptodome-3.10.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:6260e24d41149268122dd39d4ebd5941e9d107f49463f7e071fd397e29923b0c"},
+    {file = "pycryptodome-3.10.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:3f840c49d38986f6e17dbc0673d37947c88bc9d2d9dba1c01b979b36f8447db1"},
+    {file = "pycryptodome-3.10.1-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:2dea65df54349cdfa43d6b2e8edb83f5f8d6861e5cf7b1fbc3e34c5694c85e27"},
+    {file = "pycryptodome-3.10.1-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:e61e363d9a5d7916f3a4ce984a929514c0df3daf3b1b2eb5e6edbb131ee771cf"},
+    {file = "pycryptodome-3.10.1-cp27-cp27m-manylinux2014_aarch64.whl", hash = "sha256:2603c98ae04aac675fefcf71a6c87dc4bb74a75e9071ae3923bbc91a59f08d35"},
+    {file = "pycryptodome-3.10.1-cp27-cp27m-win32.whl", hash = "sha256:38661348ecb71476037f1e1f553159b80d256c00f6c0b00502acac891f7116d9"},
+    {file = "pycryptodome-3.10.1-cp27-cp27m-win_amd64.whl", hash = "sha256:1723ebee5561628ce96748501cdaa7afaa67329d753933296321f0be55358dce"},
+    {file = "pycryptodome-3.10.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:77997519d8eb8a4adcd9a47b9cec18f9b323e296986528186c0e9a7a15d6a07e"},
+    {file = "pycryptodome-3.10.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:99b2f3fc51d308286071d0953f92055504a6ffe829a832a9fc7a04318a7683dd"},
+    {file = "pycryptodome-3.10.1-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:e0a4d5933a88a2c98bbe19c0c722f5483dc628d7a38338ac2cb64a7dbd34064b"},
+    {file = "pycryptodome-3.10.1-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:d3d6958d53ad307df5e8469cc44474a75393a434addf20ecd451f38a72fe29b8"},
+    {file = "pycryptodome-3.10.1-cp27-cp27mu-manylinux2014_aarch64.whl", hash = "sha256:a8eb8b6ea09ec1c2535bf39914377bc8abcab2c7d30fa9225eb4fe412024e427"},
+    {file = "pycryptodome-3.10.1-cp35-abi3-macosx_10_9_x86_64.whl", hash = "sha256:31c1df17b3dc5f39600a4057d7db53ac372f492c955b9b75dd439f5d8b460129"},
+    {file = "pycryptodome-3.10.1-cp35-abi3-manylinux1_i686.whl", hash = "sha256:a3105a0eb63eacf98c2ecb0eb4aa03f77f40fbac2bdde22020bb8a536b226bb8"},
+    {file = "pycryptodome-3.10.1-cp35-abi3-manylinux1_x86_64.whl", hash = "sha256:a92d5c414e8ee1249e850789052608f582416e82422502dc0ac8c577808a9067"},
+    {file = "pycryptodome-3.10.1-cp35-abi3-manylinux2010_i686.whl", hash = "sha256:60386d1d4cfaad299803b45a5bc2089696eaf6cdd56f9fc17479a6f89595cfc8"},
+    {file = "pycryptodome-3.10.1-cp35-abi3-manylinux2010_x86_64.whl", hash = "sha256:501ab36aae360e31d0ec370cf5ce8ace6cb4112060d099b993bc02b36ac83fb6"},
+    {file = "pycryptodome-3.10.1-cp35-abi3-manylinux2014_aarch64.whl", hash = "sha256:fc7489a50323a0df02378bc2fff86eb69d94cc5639914346c736be981c6a02e7"},
+    {file = "pycryptodome-3.10.1-cp35-abi3-win32.whl", hash = "sha256:9b6f711b25e01931f1c61ce0115245a23cdc8b80bf8539ac0363bdcf27d649b6"},
+    {file = "pycryptodome-3.10.1-cp35-abi3-win_amd64.whl", hash = "sha256:7fd519b89585abf57bf47d90166903ec7b43af4fe23c92273ea09e6336af5c07"},
+    {file = "pycryptodome-3.10.1-pp27-pypy_73-macosx_10_9_x86_64.whl", hash = "sha256:09c1555a3fa450e7eaca41ea11cd00afe7c91fef52353488e65663777d8524e0"},
+    {file = "pycryptodome-3.10.1-pp27-pypy_73-manylinux1_x86_64.whl", hash = "sha256:758949ca62690b1540dfb24ad773c6da9cd0e425189e83e39c038bbd52b8e438"},
+    {file = "pycryptodome-3.10.1-pp27-pypy_73-manylinux2010_x86_64.whl", hash = "sha256:e3bf558c6aeb49afa9f0c06cee7fb5947ee5a1ff3bd794b653d39926b49077fa"},
+    {file = "pycryptodome-3.10.1-pp27-pypy_73-win32.whl", hash = "sha256:f977cdf725b20f6b8229b0c87acb98c7717e742ef9f46b113985303ae12a99da"},
+    {file = "pycryptodome-3.10.1-pp36-pypy36_pp73-macosx_10_9_x86_64.whl", hash = "sha256:6d2df5223b12437e644ce0a3be7809471ffa71de44ccd28b02180401982594a6"},
+    {file = "pycryptodome-3.10.1-pp36-pypy36_pp73-manylinux1_x86_64.whl", hash = "sha256:98213ac2b18dc1969a47bc65a79a8fca02a414249d0c8635abb081c7f38c91b6"},
+    {file = "pycryptodome-3.10.1-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:12222a5edc9ca4a29de15fbd5339099c4c26c56e13c2ceddf0b920794f26165d"},
+    {file = "pycryptodome-3.10.1-pp36-pypy36_pp73-win32.whl", hash = "sha256:6bbf7fee7b7948b29d7e71fcacf48bac0c57fb41332007061a933f2d996f9713"},
+    {file = "pycryptodome-3.10.1.tar.gz", hash = "sha256:3e2e3a06580c5f190df843cdb90ea28d61099cf4924334d5297a995de68e4673"},
+]
+python-dateutil = [
+    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
+    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+]
+pyyaml = [
+    {file = "PyYAML-5.4.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922"},
+    {file = "PyYAML-5.4.1-cp27-cp27m-win32.whl", hash = "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393"},
+    {file = "PyYAML-5.4.1-cp27-cp27m-win_amd64.whl", hash = "sha256:4465124ef1b18d9ace298060f4eccc64b0850899ac4ac53294547536533800c8"},
+    {file = "PyYAML-5.4.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-win32.whl", hash = "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-win32.whl", hash = "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf"},
+    {file = "PyYAML-5.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46"},
+    {file = "PyYAML-5.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb"},
+    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247"},
+    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc"},
+    {file = "PyYAML-5.4.1-cp38-cp38-win32.whl", hash = "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc"},
+    {file = "PyYAML-5.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696"},
+    {file = "PyYAML-5.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77"},
+    {file = "PyYAML-5.4.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183"},
+    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122"},
+    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6"},
+    {file = "PyYAML-5.4.1-cp39-cp39-win32.whl", hash = "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10"},
+    {file = "PyYAML-5.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db"},
+    {file = "PyYAML-5.4.1.tar.gz", hash = "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"},
 ]
 regex = [
     {file = "regex-2021.8.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:8764a78c5464ac6bde91a8c87dd718c27c1cabb7ed2b4beaf36d3e8e390567f9"},
@@ -144,7 +634,44 @@ regex = [
     {file = "regex-2021.8.3-cp39-cp39-win_amd64.whl", hash = "sha256:bfa6a679410b394600eafd16336b2ce8de43e9b13f7fb9247d84ef5ad2b45e91"},
     {file = "regex-2021.8.3.tar.gz", hash = "sha256:8935937dad2c9b369c3d932b0edbc52a62647c2afb2fafc0c280f14a8bf56a6a"},
 ]
+requests = [
+    {file = "requests-2.26.0-py2.py3-none-any.whl", hash = "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24"},
+    {file = "requests-2.26.0.tar.gz", hash = "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"},
+]
+requests-oauthlib = [
+    {file = "requests-oauthlib-1.3.0.tar.gz", hash = "sha256:b4261601a71fd721a8bd6d7aa1cc1d6a8a93b4a9f5e96626f8e4d91e8beeaa6a"},
+    {file = "requests_oauthlib-1.3.0-py2.py3-none-any.whl", hash = "sha256:7f71572defaecd16372f9006f33c2ec8c077c3cfa6f5911a9a90202beb513f3d"},
+    {file = "requests_oauthlib-1.3.0-py3.7.egg", hash = "sha256:fa6c47b933f01060936d87ae9327fead68768b69c6c9ea2109c48be30f2d4dbc"},
+]
+rsa = [
+    {file = "rsa-4.7.2-py3-none-any.whl", hash = "sha256:78f9a9bf4e7be0c5ded4583326e7461e3a3c5aae24073648b4bdfa797d78c9d2"},
+    {file = "rsa-4.7.2.tar.gz", hash = "sha256:9d689e6ca1b3038bc82bf8d23e944b6b6037bc02301a574935b2dd946e0353b9"},
+]
+six = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+toml = [
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
 tomli = [
     {file = "tomli-1.2.1-py3-none-any.whl", hash = "sha256:8dd0e9524d6f386271a36b41dbf6c57d8e32fd96fd22b6584679dc569d20899f"},
     {file = "tomli-1.2.1.tar.gz", hash = "sha256:a5b75cb6f3968abb47af1b40c1819dc519ea82bcc065776a866e8d74c5ca9442"},
+]
+tutor = [
+    {file = "tutor-12.0.4.tar.gz", hash = "sha256:9ed19cfab6e73b23042dcba6eab631e3ffec074945c36c0b0cb482d3aa3a709e"},
+]
+typing-extensions = [
+    {file = "typing_extensions-3.10.0.0-py2-none-any.whl", hash = "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497"},
+    {file = "typing_extensions-3.10.0.0-py3-none-any.whl", hash = "sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84"},
+    {file = "typing_extensions-3.10.0.0.tar.gz", hash = "sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342"},
+]
+urllib3 = [
+    {file = "urllib3-1.26.6-py2.py3-none-any.whl", hash = "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4"},
+    {file = "urllib3-1.26.6.tar.gz", hash = "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"},
+]
+websocket-client = [
+    {file = "websocket-client-1.2.0.tar.gz", hash = "sha256:7665ba6c645989b28b61670874ab753e6929179e9fc90565ace6ac090f59c559"},
+    {file = "websocket_client-1.2.0-py2.py3-none-any.whl", hash = "sha256:d82a975bdd02216f7884cd18106a0d9896a9a9e8cc90f23fe8c81dc48da2f142"},
 ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -67,6 +67,18 @@ python-versions = ">=3.6"
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
+name = "cloup"
+version = "0.11.0"
+description = "Adds features to Click: option groups, constraints, subcommand sections and help themes."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+click = ">=7.1,<9.0"
+typing-extensions = {version = "*", markers = "python_version <= \"3.8\""}
+
+[[package]]
 name = "colorama"
 version = "0.4.4"
 description = "Cross-platform colored terminal text."
@@ -362,7 +374,7 @@ python-versions = ">=3.6"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "f2e75e2fe63089fc3b5bb4158bc08e8d9c21379fcdc0de477a98877282b0c839"
+content-hash = "1a8529613b4b17f27cfd89bc8a4d112cadc4dbc21eef877d1c9a9aed7d2b80d2"
 
 [metadata.files]
 appdirs = [
@@ -388,6 +400,10 @@ charset-normalizer = [
 click = [
     {file = "click-8.0.1-py3-none-any.whl", hash = "sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6"},
     {file = "click-8.0.1.tar.gz", hash = "sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a"},
+]
+cloup = [
+    {file = "cloup-0.11.0-py2.py3-none-any.whl", hash = "sha256:b646cd5ae988a46e24497b26dd41e6b82dc0bafca105bf879bb8ff2079d77910"},
+    {file = "cloup-0.11.0.tar.gz", hash = "sha256:2ba279ee2544a4ef1c1748731a6698b3d1f5db929357b7123f23d0ba02e27d1e"},
 ]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
 python = "^3.8"
 click = "^8.0.1"
 tutor = "^12.0.4"
+cloup = "^0.11.0"
 
 [tool.poetry.dev-dependencies]
 black = "^21.7b0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
+click = "^8.0.1"
+tutor = "^12.0.4"
 
 [tool.poetry.dev-dependencies]
 black = "^21.7b0"

--- a/tutor_recon/commands/recon.py
+++ b/tutor_recon/commands/recon.py
@@ -1,0 +1,68 @@
+"""The Recon CLI definitions."""
+
+import json
+from pathlib import Path
+
+import click
+import cloup
+
+from tutor_recon.config.main import get_all_mappings, override_all, scaffold_all
+from tutor_recon.util.cli import emit
+from tutor_recon.util.paths import overrides_path
+
+
+@cloup.group(
+    help="Allows overriding and rendering settings, files, and templates (in their entirety) from a central location."
+)
+def recon():
+    pass
+
+
+@recon.command(help="Initialize recon.")
+@cloup.option(
+    "--env-dir",
+    help="The path to where your environment override files should (or already do) reside.",
+    type=cloup.Path(file_okay=False, path_type=Path),
+    default=None,
+)
+@cloup.option(
+    "--reset-location",
+    help="Reset the environment overrides directory location to default (has no effect if the directory is already in the default location).",
+    is_flag=True,
+)
+@cloup.pass_obj
+def init(context: cloup.Context, env_dir=None, reset_location=False):
+    tutor_root = Path(context.root)
+    if reset_location:
+        overrides_path(tutor_root=tutor_root).unlink(missing_ok=True)
+        recon_root = overrides_path(tutor_root=tutor_root)
+        emit(f"Set the new environment overrides location to {recon_root}.")
+    else:
+        recon_root = overrides_path(tutor_root=tutor_root, env_dir=env_dir).resolve()
+    scaffold_all(tutor_root, recon_root)
+    emit(
+        f"You're all set! Your environment overrides can be configured at '{recon_root}'."
+    )
+
+
+@recon.command(help="Echo the location of the config overrides directory over stdout.")
+@cloup.pass_obj
+def printroot(context: cloup.Context):
+    tutor_root = Path(context.root)
+    click.echo(overrides_path(tutor_root).resolve())
+
+
+@recon.command(help="Apply all override settings to the rendered environment.")
+@cloup.pass_obj
+def save(context: cloup.Context):
+    tutor_root = Path(context.root)
+    recon_root = overrides_path(tutor_root).resolve()
+    override_all(tutor_root, recon_root)
+
+
+@recon.command(help="Echo all settings, with overrides applied, over stdout in JSON format.")
+@cloup.pass_obj
+def list(context: cloup.Context):
+    tutor_root = Path(context.root)
+    recon_root = overrides_path(tutor_root).resolve()
+    click.echo(json.dumps(get_all_mappings(tutor_root, recon_root), indent=4))

--- a/tutor_recon/commands/recon.py
+++ b/tutor_recon/commands/recon.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import click
 import cloup
 
-from tutor_recon.config.main import get_all_mappings, override_all, scaffold_all
+from tutor_recon.config.main import get_all_mappings, main_config, override_all, scaffold_all
 from tutor_recon.util.cli import emit
 from tutor_recon.util.paths import overrides_path
 

--- a/tutor_recon/commands/recon.py
+++ b/tutor_recon/commands/recon.py
@@ -16,6 +16,11 @@ from tutor_recon.util.cli import emit
 from tutor_recon.util.paths import overrides_path, root_dirs
 from tutor_recon.commands.tutor import tutor_config_save
 
+CONFIG_SAVE_STYLED = click.style("tutor config save", fg="blue")
+
+def run_tutor_config_save(context: cloup.Context) -> None:
+    emit(f"Running '{CONFIG_SAVE_STYLED}'.")
+    context.invoke(tutor_config_save)
 
 @cloup.group(
     help="Allows overriding and rendering settings, files, and templates (in their entirety) from a central location."
@@ -36,8 +41,9 @@ def recon():
     help="Reset the environment overrides directory location to default (has no effect if the directory is already in the default location).",
     is_flag=True,
 )
+@cloup.option("--tutor/--no-tutor", is_flag=True, default=True, help="Run/don't run 'tutor config save' prior to applying overrides.")
 @cloup.pass_context
-def init(context: cloup.Context, env_dir=None, reset_location=False):
+def init(context: cloup.Context, env_dir, reset_location, tutor):
     tutor_root = Path(context.obj.root)
     if reset_location:
         overrides_path(tutor_root=tutor_root).unlink(missing_ok=True)
@@ -45,6 +51,8 @@ def init(context: cloup.Context, env_dir=None, reset_location=False):
         emit(f"Set the new environment overrides location to {recon_root}.")
     else:
         recon_root = overrides_path(tutor_root=tutor_root, env_dir=env_dir).resolve()
+    if tutor:
+        run_tutor_config_save(context)
     scaffold_all(tutor_root, recon_root)
     emit(
         f"You're all set! Your environment overrides can be configured at '{recon_root}'."
@@ -59,13 +67,12 @@ def printroot(context: cloup.Context):
 
 
 @recon.command(help="Apply all override settings to the rendered environment.")
-@cloup.option("--tutor/--no-tutor", is_flag=True, default=True)
+@cloup.option("--tutor/--no-tutor", is_flag=True, default=True, help="Run/don't run 'tutor config save' prior to applying overrides.")
 @cloup.pass_context
 def save(context: cloup.Context, tutor):
     tutor_root, recon_root = root_dirs(context)
     if tutor:
-        emit("Running 'tutor config save'.")
-        context.invoke(tutor_config_save)
+        run_tutor_config_save(context)
     emit("Applying overrides.")
     override_all(tutor_root, recon_root)
 

--- a/tutor_recon/commands/recon.py
+++ b/tutor_recon/commands/recon.py
@@ -2,11 +2,17 @@
 
 import json
 from pathlib import Path
+from tutor_recon.util.vjson import VJSONEncoder
 
 import click
 import cloup
 
-from tutor_recon.config.main import get_all_mappings, main_config, override_all, scaffold_all
+from tutor_recon.config.main import (
+    get_all_mappings,
+    main_config,
+    override_all,
+    scaffold_all,
+)
 from tutor_recon.util.cli import emit
 from tutor_recon.util.paths import overrides_path
 
@@ -60,9 +66,23 @@ def save(context: cloup.Context):
     override_all(tutor_root, recon_root)
 
 
-@recon.command(help="Echo all settings, with overrides applied, over stdout in JSON format.")
+@recon.command(
+    help="Echo all settings, with overrides applied, over stdout in JSON format."
+)
+@cloup.option(
+    "--all",
+    default=False,
+    help="Show the complete mapping of all overrides for all files.",
+    is_flag=True,
+)
 @cloup.pass_obj
-def list(context: cloup.Context):
+def list(context: cloup.Context, all: bool):
     tutor_root = Path(context.root)
     recon_root = overrides_path(tutor_root).resolve()
-    click.echo(json.dumps(get_all_mappings(tutor_root, recon_root), indent=4))
+    print(
+        json.dumps(
+            get_all_mappings(tutor_root, recon_root),
+            indent=4,
+            cls=VJSONEncoder.make_encoder(recon_root, expand_remote_mappings=all),
+        )
+    )

--- a/tutor_recon/commands/recon.py
+++ b/tutor_recon/commands/recon.py
@@ -18,9 +18,11 @@ from tutor_recon.commands.tutor import tutor_config_save
 
 CONFIG_SAVE_STYLED = click.style("tutor config save", fg="blue")
 
+
 def run_tutor_config_save(context: cloup.Context) -> None:
     emit(f"Running '{CONFIG_SAVE_STYLED}'.")
     context.invoke(tutor_config_save)
+
 
 @cloup.group(
     help="Allows overriding and rendering settings, files, and templates (in their entirety) from a central location."
@@ -41,7 +43,12 @@ def recon():
     help="Reset the environment overrides directory location to default (has no effect if the directory is already in the default location).",
     is_flag=True,
 )
-@cloup.option("--tutor/--no-tutor", is_flag=True, default=True, help="Run/don't run 'tutor config save' prior to applying overrides.")
+@cloup.option(
+    "--tutor/--no-tutor",
+    is_flag=True,
+    default=True,
+    help="Run/don't run 'tutor config save' prior to applying overrides.",
+)
 @cloup.pass_context
 def init(context: cloup.Context, env_dir, reset_location, tutor):
     tutor_root = Path(context.obj.root)
@@ -67,7 +74,12 @@ def printroot(context: cloup.Context):
 
 
 @recon.command(help="Apply all override settings to the rendered environment.")
-@cloup.option("--tutor/--no-tutor", is_flag=True, default=True, help="Run/don't run 'tutor config save' prior to applying overrides.")
+@cloup.option(
+    "--tutor/--no-tutor",
+    is_flag=True,
+    default=True,
+    help="Run/don't run 'tutor config save' prior to applying overrides.",
+)
 @cloup.pass_context
 def save(context: cloup.Context, tutor):
     tutor_root, recon_root = root_dirs(context)

--- a/tutor_recon/commands/tutor.py
+++ b/tutor_recon/commands/tutor.py
@@ -1,0 +1,5 @@
+"""Re-exports of Tutor commands are added to this file as needed."""
+
+import tutor.commands.config
+
+tutor_config_save = tutor.commands.config.save

--- a/tutor_recon/config/main.py
+++ b/tutor_recon/config/main.py
@@ -1,135 +1,55 @@
-"""Tools for working with the main configuration override."""
+"""The MainConfig class definition and associated utility functions."""
 
 import json
-from abc import ABC, abstractmethod
 from pathlib import Path
-from tutor_recon.util.misc import recursive_update, set_nested, walk_dict
-from tutor_recon.util.paths import overrides_path
 from typing import Optional
 
-from tutor_recon.util.vjson import RemoteMapping, VJSONEncoder, format_unset, VJSONDecoder
-from tutor_recon.config.tutor import update_config, get_complete
+from tutor_recon.util.misc import recursive_update
+from tutor_recon.util.vjson import (
+    RemoteMapping,
+    VJSONEncoder,
+)
+from tutor_recon.config.override import (
+    OverrideConfig,
+    JSONOverrideConfig,
+    TutorOverrideConfig,
+)
 
 
-class OverrideConfig(ABC):
-    """An override configuration object."""
-
-    def __init__(
-        self,
-        recon_path: Path,
-        env_path: Path,
-    ) -> None:
-        """
-        Arguments:
-            recon_path: The Path, relative to the recon root, where this configuration's overrides are stored.
-            env_path: The Path, relative to the Tutor root, to the final destination of this file.
-            serialize: Convert a dictionary of settings into a string representation.
-            deserialize: Convert a string into a dictionary of settings.
-        """
-        self.recon_path = recon_path
-        self.env_path = env_path
-
-    @abstractmethod
-    def load_from_env(self, tutor_root: Path) -> dict:
-        """Load this configuration's settings from the current Tutor environment.
-
-        Ideally all possible keys should be present along with their current or default values.
-        """
-
-    @abstractmethod
-    def update_env(self, tutor_root: Path, override_settings: dict) -> None:
-        """Update the environment with the given settings."""
-
-    def get_scaffold(self, tutor_root: Path) -> dict:
-        """Return a dict mapping (all) possible keys for this config to `'$default'`."""
-        env = self.load_from_env(tutor_root)
-        ret = dict()
-        for key_list, value in walk_dict(env):
-            set_nested(ret, key_list, format_unset(value))
-        return ret
-
-    def get_complete(self, tutor_root: Path, recon_root: Path) -> "list[dict]":
-        """Return the full scaffold of this Config with all overrides applied."""
-        scaffold = self.get_scaffold(tutor_root)
-        overrides = self.load_override_config(recon_root)
-        recursive_update(scaffold, overrides)
-        return scaffold
-
-    def with_new_overrides(self, overrides: dict, tutor_root: Path, recon_root: Path) -> dict:
-        """Get the complete configuration dict with the given new overrides also applied."""
-        complete = self.get_complete(tutor_root, recon_root)
-        recursive_update(complete, overrides)
-        return complete
-
-    def override(self, tutor_root: Path, recon_root: Path) -> None:
-        """Apply the override settings to the environment.
-        
-        To also apply new overrides, first call `write_override_file` with the new settings,
-        the call this method.
-        """
-        self.update_env(tutor_root, self.load_override_config(recon_root))
-
-    def load_override_config(self, recon_root: Path) -> dict:
-        """Load the explicitly set override values from the relevant recon override file."""
-        override_path = recon_root / self.recon_path
-        if not override_path.exists():
-            return dict()
-        with open(override_path, "r") as f:
-            return json.load(f, cls=VJSONDecoder.relative_decoder(override_path.parent))
-
-    def save_override_config(
-        self, tutor_root: Path, recon_root: Path, settings: Optional[dict] = None
-    ) -> None:
-        """Write the .v.json file of this config's scaffold updated with the values in `settings`.
-
-        Non-destructive in the sense that existing override values, if any, will not be lost (unless
-        overwritten by a value from the `settings` parameter). To force the file to be overwritten,
-        just delete it first and this method will regenerate it.
-        """
-        if settings is None:
-            settings = dict()
-        complete = self.with_new_overrides(settings, tutor_root, recon_root)
-        override_path = recon_root / self.recon_path
-        override_dir = override_path.parent
-        override_dir.mkdir(exist_ok=True, parents=True)
-        with open(override_path, "w") as f:
-            json.dump(complete, f, indent=4, cls=VJSONEncoder.relative_encoder(override_dir))
-
-
-class TutorOverrideConfig(OverrideConfig):
-    def load_from_env(self, tutor_root: Path) -> dict:
-        return get_complete(tutor_root).copy()
-
-    def update_env(self, tutor_root: Path, override_settings: dict) -> None:
-        env = self.load_from_env(tutor_root)
-        recursive_update(env, override_settings)
-        update_config(tutor_root, settings=env)
-
-
-class JSONOverrideConfig(OverrideConfig):
-    def load_from_env(self, tutor_root: Path) -> dict:
-        with open(tutor_root / self.env_path, "r") as f:
-            return json.load(f)
-
-    def update_env(self, tutor_root: Path, override_settings: dict) -> None:
-        env = self.load_from_env(tutor_root)
-        recursive_update(env, override_settings)
-        with open(tutor_root / self.env_path, "w") as f:
-            json.dump(env, f)
-
-class MainConfig(OverrideConfig):
-    def __init__(self, recon_path: Path, configs: "dict[str, OverrideConfig]") -> None:
-        super().__init__(recon_path, None)
+class MainConfig:
+    def __init__(self, configs: "dict[str, OverrideConfig]") -> None:
         self._configs = configs
 
-    def load_from_env(self, tutor_root: Path) -> dict:
+    def load(self, tutor_root: Path, recon_root: Path) -> dict:
+        # FIXME this should really dynamically gather the OverrideConfig objects based on the contents of main.v.json.
         return {
-            config.env_path: RemoteMapping(config.load_from_env(tutor_root)) for config in self._configs.values()
+            str(path): RemoteMapping(
+                config.recon_path, **config.load_from_env(tutor_root)
+            )
+            for path, config in self._configs.items()
         }
 
-    def update_env(self, tutor_root: Path, override_settings: dict) -> None:
-        for k, v in self._configs.items():
-            v.update_env(tutor_root, override_settings.get(k, dict()))
+    def save(
+        self,
+        tutor_root: Path,
+        recon_root: Path,
+        override_settings: Optional[dict] = None,
+    ) -> None:
+        override_settings = override_settings if override_settings else dict()
+        env = self.load(tutor_root, recon_root)
+        recursive_update(env, override_settings)
+        main_path = recon_root / "main.v.json"
+        with open(main_path, "w") as f:
+            json.dump(
+                env,
+                f,
+                cls=VJSONEncoder.make_encoder(recon_root, write_remote_mappings=True),
+                indent=4,
+            )
+
+    def override(self, tutor_root: Path, recon_root: Path) -> None:
+        for config in self._configs.values():
+            config.override(tutor_root, recon_root)
 
 
 JSON_CONFIG_MAP = {
@@ -147,26 +67,30 @@ def get_all_configs() -> "list[OverrideConfig]":
     ]
     return [tutor_config] + json_configs
 
+
 def main_config() -> MainConfig:
     config_map = {
-        "tutor_config.yml": TutorOverrideConfig(recon_path=Path("tutor_config.yml"), env_path=Path("config.yml"))
+        "config.yml": TutorOverrideConfig(
+            recon_path=Path("tutor_config.yml"), env_path=Path("config.yml")
+        )
     }
-    config_map.update({k: JSONOverrideConfig(recon_path=v, env_path=k) for k, v in JSON_CONFIG_MAP.items()})
-    return MainConfig("main.v.json", config_map)
+    config_map.update(
+        {
+            k: JSONOverrideConfig(recon_path=Path(v), env_path=Path(k))
+            for k, v in JSON_CONFIG_MAP.items()
+        }
+    )
+    return MainConfig(config_map)
+
 
 def get_all_mappings(tutor_root: str, recon_root: str) -> "list[dict]":
     """Get all configurations with overrides applied, mapped by their `env_path`."""
-    return {str(conf.env_path): conf.get_complete(tutor_root, recon_root) for conf in get_all_configs()}
-    # return main_config().get_complete(tutor_root, recon_root)
+    return main_config().load(tutor_root, recon_root)
 
 
 def scaffold_all(tutor_root: str, recon_root: str) -> None:
-    # main_config().save_override_config(tutor_root, recon_root)
-    for conf in get_all_configs():
-        conf.save_override_config(tutor_root, recon_root)
+    main_config().save(tutor_root, recon_root)
 
 
 def override_all(tutor_root: str, recon_root: str) -> None:
-    # main_config().override(tutor_root, recon_root)
-    for conf in get_all_configs():
-        conf.override(tutor_root, recon_root)
+    main_config().override(tutor_root, recon_root)

--- a/tutor_recon/config/main.py
+++ b/tutor_recon/config/main.py
@@ -1,0 +1,119 @@
+"""Tools for working with the main configuration override."""
+
+import json
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Optional
+
+from tutor_recon.util.vjson import VJSONDecoder, format_unset
+from tutor_recon.config.tutor import update_config, get_complete, get_current
+
+
+class OverrideConfig(ABC):
+    """An override configuration object."""
+
+    def __init__(
+        self,
+        recon_path: Path,
+        env_path: Path,
+    ) -> None:
+        """
+        Arguments:
+            recon_path: The Path, relative to the recon root, where this configuration's overrides are stored.
+            env_path: The Path, relative to the Tutor root, to the final destination of this file.
+            serialize: Convert a dictionary of settings into a string representation.
+            deserialize: Convert a string into a dictionary of settings.
+        """
+        self.recon_path = recon_path
+        self.env_path = env_path
+
+    @abstractmethod
+    def load_from_env(self, tutor_root: Path) -> dict:
+        """Load this configuration's settings from the current Tutor environment."""
+
+    @abstractmethod
+    def get_scaffold(self, tutor_root: Path) -> dict:
+        """Return a dict mapping all possible keys for this config to `'$default'`."""
+
+    @abstractmethod
+    def replace(self, tutor_root: Path, override_settings: dict) -> None:
+        """Update the environment with the given settings."""
+
+    def override(self, tutor_root: Path, recon_root: Path) -> None:
+        """Apply the override settings to the environment."""
+        self.replace(tutor_root, self.load_override_config(recon_root))
+
+    def load_override_config(self, recon_root: Path) -> dict:
+        """Load the explicitly set override values from the relevant recon override file."""
+        override_path = recon_root / self.recon_path
+        if not override_path.exists():
+            return dict()
+        with open(recon_root / self.recon_path, 'r') as f:
+            return json.load(f, cls=VJSONDecoder)
+
+    def write_override_file(self, tutor_root: Path, recon_root: Path, settings: Optional[dict] = None) -> None:
+        """Write the .v.json file of this config's scaffold updated with the values in `settings`.
+        
+        Non-destructive in the sense that existing override values, if any, will not be lost (unless
+        overwritten by a value from the `settings` parameter). To force the file to be overwritten,
+        just delete it first and this method will regenerate it.
+        """
+        if settings is None:
+            settings = dict()
+        scaffold = self.get_scaffold(tutor_root)
+        scaffold.update(self.load_override_config(recon_root))
+        scaffold.update(settings)
+        override_path = recon_root / self.recon_path
+        override_dir = override_path.parent
+        override_dir.mkdir(exist_ok=True, parents=True)
+        with open(override_path, 'w') as f:
+            json.dump(scaffold, f, indent=4)
+
+
+class TutorOverrideConfig(OverrideConfig):
+    def load_from_env(self, tutor_root: Path) -> dict:
+        return get_complete(tutor_root).copy()
+
+    def get_scaffold(self, tutor_root: Path) -> dict:
+        return {k: format_unset(v) for k, v in get_current(tutor_root).items()}
+
+    def replace(self, tutor_root: Path, override_settings: dict) -> None:
+        env = self.load_from_env(tutor_root)
+        env.update(override_settings)
+        return update_config(tutor_root, settings=env)
+
+
+class JSONOverrideConfig(OverrideConfig):
+    def load_from_env(self, tutor_root: Path) -> dict:
+        with open(tutor_root / self.env_path, 'r') as f:
+            return json.load(f)
+
+    def get_scaffold(self, tutor_root: Path) -> dict:
+        env = self.load_from_env(tutor_root)
+        return {k: format_unset(v) for k, v in env.items()}
+
+    def replace(self, tutor_root: Path, override_settings: dict) -> None:
+        env = self.load_from_env(tutor_root)
+        env.update(override_settings)
+        with open(tutor_root / self.env_path, 'w') as f:
+            json.dump(env, f)
+
+
+JSON_CONFIG_MAP = {
+    'env/apps/openedx/config/cms.env.json': 'openedx/cms.env.v.json',
+    'env/apps/openedx/config/lms.env.json': 'openedx/lms.env.v.json'
+}
+
+def get_all_configs() -> 'list[OverrideConfig]':
+    tutor_config = TutorOverrideConfig(recon_path=Path('tutor_config.yml'), env_path=Path('config.yml'))
+    json_configs = [JSONOverrideConfig(recon_path=v, env_path=k) for k, v in JSON_CONFIG_MAP.items()]
+    return [tutor_config] + json_configs
+
+
+def scaffold_all(tutor_root: str, recon_root: str) -> None:
+    for conf in get_all_configs():
+        conf.write_override_file(tutor_root, recon_root)
+
+def override_all(tutor_root: str, recon_root: str) -> None:
+    for conf in get_all_configs():
+        conf.override(tutor_root, recon_root)

--- a/tutor_recon/config/main.py
+++ b/tutor_recon/config/main.py
@@ -1,13 +1,12 @@
 """The MainConfig class definition and associated utility functions."""
 
-import json
 from pathlib import Path
 from typing import Optional
 
 from tutor_recon.util.misc import recursive_update
 from tutor_recon.util.vjson import (
     RemoteMapping,
-    VJSONEncoder,
+    dump,
 )
 from tutor_recon.config.override import (
     OverrideConfig,
@@ -46,13 +45,7 @@ class MainConfig:
         recursive_update(env, override_settings)
         main_path = recon_root / "main.v.json"
         recon_root.mkdir(exist_ok=True, parents=True)
-        with open(main_path, "w") as f:
-            json.dump(
-                env,
-                f,
-                cls=VJSONEncoder.make_encoder(recon_root, write_remote_mappings=True),
-                indent=4,
-            )
+        dump(env, main_path, location=recon_root)
 
     def apply_overrides(self, tutor_root: Path, recon_root: Path) -> None:
         for config in self._configs.values():

--- a/tutor_recon/config/override.py
+++ b/tutor_recon/config/override.py
@@ -11,9 +11,9 @@ from tutor_recon.util.misc import (
     walk_dict,
 )
 from tutor_recon.util.vjson import (
-    VJSONEncoder,
+    dump,
     format_unset,
-    VJSONDecoder,
+    load,
 )
 from tutor_recon.config.tutor import update_config, get_complete
 
@@ -83,8 +83,7 @@ class OverrideConfig(ABC):
         override_path = recon_root / self.recon_path
         if not override_path.exists():
             return dict()
-        with open(override_path, "r") as f:
-            return json.load(f, cls=VJSONDecoder.relative_decoder(override_path.parent))
+        return load(override_path, location=override_path.parent)
 
     def save_override_config(
         self, tutor_root: Path, recon_root: Path, settings: Optional[dict] = None
@@ -101,13 +100,7 @@ class OverrideConfig(ABC):
         override_path = recon_root / self.recon_path
         override_dir = override_path.parent
         override_dir.mkdir(exist_ok=True, parents=True)
-        with open(override_path, "w") as f:
-            json.dump(
-                complete,
-                f,
-                indent=4,
-                cls=VJSONEncoder.make_encoder(override_dir, write_remote_mappings=True),
-            )
+        dump(complete, override_path, location=override_dir)
 
 
 class TutorOverrideConfig(OverrideConfig):

--- a/tutor_recon/config/override.py
+++ b/tutor_recon/config/override.py
@@ -1,0 +1,132 @@
+"""The OverrideConfig class and subclass definitions."""
+
+import json
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Optional
+
+from tutor_recon.util.misc import (
+    recursive_update,
+    set_nested,
+    walk_dict,
+)
+from tutor_recon.util.vjson import (
+    VJSONEncoder,
+    format_unset,
+    VJSONDecoder,
+)
+from tutor_recon.config.tutor import update_config, get_complete
+
+
+class OverrideConfig(ABC):
+    """An override configuration object."""
+
+    def __init__(
+        self,
+        recon_path: Path,
+        env_path: Path,
+    ) -> None:
+        """
+        Arguments:
+            recon_path: The Path, relative to the recon root, where this configuration's overrides are stored.
+            env_path: The Path, relative to the Tutor root, to the final destination of this file.
+            serialize: Convert a dictionary of settings into a string representation.
+            deserialize: Convert a string into a dictionary of settings.
+        """
+        self.recon_path = recon_path
+        self.env_path = env_path
+
+    @abstractmethod
+    def load_from_env(self, tutor_root: Path) -> dict:
+        """Load this configuration's settings from the current Tutor environment.
+
+        Ideally all possible keys should be present along with their current or default values.
+        """
+
+    @abstractmethod
+    def update_env(self, tutor_root: Path, override_settings: dict) -> None:
+        """Update the environment with the given settings."""
+
+    def get_scaffold(self, tutor_root: Path) -> dict:
+        """Return a dict mapping (all) possible keys for this config to `'$default'`."""
+        env = self.load_from_env(tutor_root)
+        ret = dict()
+        for key_list, value in walk_dict(env):
+            set_nested(ret, key_list, format_unset(value))
+        return ret
+
+    def get_complete(self, tutor_root: Path, recon_root: Path) -> "list[dict]":
+        """Return the full scaffold of this Config with all overrides applied."""
+        scaffold = self.get_scaffold(tutor_root)
+        overrides = self.load_override_config(recon_root)
+        recursive_update(scaffold, overrides)
+        return scaffold
+
+    def with_new_overrides(
+        self, overrides: dict, tutor_root: Path, recon_root: Path
+    ) -> dict:
+        """Get the complete configuration dict with the given new overrides also applied."""
+        complete = self.get_complete(tutor_root, recon_root)
+        recursive_update(complete, overrides)
+        return complete
+
+    def override(self, tutor_root: Path, recon_root: Path) -> None:
+        """Apply the override settings to the environment.
+
+        To also apply new overrides, first call `write_override_file` with the new settings,
+        the call this method.
+        """
+        self.update_env(tutor_root, self.load_override_config(recon_root))
+
+    def load_override_config(self, recon_root: Path) -> dict:
+        """Load the explicitly set override values from the relevant recon override file."""
+        override_path = recon_root / self.recon_path
+        if not override_path.exists():
+            return dict()
+        with open(override_path, "r") as f:
+            return json.load(f, cls=VJSONDecoder.relative_decoder(override_path.parent))
+
+    def save_override_config(
+        self, tutor_root: Path, recon_root: Path, settings: Optional[dict] = None
+    ) -> None:
+        """Write the .v.json file of this config's scaffold updated with the values in `settings`.
+
+        Non-destructive in the sense that existing override values, if any, will not be lost (unless
+        overwritten by a value from the `settings` parameter). To force the file to be overwritten,
+        just delete it first and this method will regenerate it.
+        """
+        if settings is None:
+            settings = dict()
+        complete = self.with_new_overrides(settings, tutor_root, recon_root)
+        override_path = recon_root / self.recon_path
+        override_dir = override_path.parent
+        override_dir.mkdir(exist_ok=True, parents=True)
+        with open(override_path, "w") as f:
+            json.dump(
+                complete,
+                f,
+                indent=4,
+                cls=VJSONEncoder.make_encoder(override_dir, write_remote_mappings=True),
+            )
+
+
+class TutorOverrideConfig(OverrideConfig):
+    def load_from_env(self, tutor_root: Path) -> dict:
+        return get_complete(tutor_root).copy()
+
+    def update_env(self, tutor_root: Path, override_settings: dict) -> None:
+        env = self.load_from_env(tutor_root)
+        recursive_update(env, override_settings)
+        update_config(tutor_root, settings=env)
+
+
+class JSONOverrideConfig(OverrideConfig):
+    def load_from_env(self, tutor_root: Path) -> dict:
+        with open(tutor_root / self.env_path, "r") as f:
+            return json.load(f)
+
+    def update_env(self, tutor_root: Path, override_settings: dict) -> None:
+        env = self.load_from_env(tutor_root)
+        recursive_update(env, override_settings)
+        with open(tutor_root / self.env_path, "w") as f:
+            json.dump(env, f)

--- a/tutor_recon/config/override.py
+++ b/tutor_recon/config/override.py
@@ -115,9 +115,7 @@ class TutorOverrideConfig(OverrideConfig):
         return get_complete(tutor_root).copy()
 
     def update_env(self, tutor_root: Path, override_settings: dict) -> None:
-        env = self.load_from_env(tutor_root)
-        recursive_update(env, override_settings)
-        update_config(tutor_root, settings=env)
+        update_config(tutor_root, settings=override_settings)
 
 
 class JSONOverrideConfig(OverrideConfig):

--- a/tutor_recon/config/tutor.py
+++ b/tutor_recon/config/tutor.py
@@ -6,27 +6,33 @@ import tutor
 
 from tutor_recon.util.vjson import escape, format_unset
 
+
 def get_defaults() -> dict:
     """Retrieve the default tutor configuration settings, unexpanded."""
     return tutor.config.load_defaults()
 
-def get_possible_keys() -> 'list[str]':
+
+def get_possible_keys() -> "list[str]":
     """Retrieve all known possible Tutor configuration keys."""
     return get_defaults().keys()
+
 
 def get_current(tutor_root: Path) -> dict:
     """Retrieve all Tutor configuration values which are currently set."""
     return tutor.config.load_current(tutor_root, defaults=get_defaults())
 
+
 def get_complete(tutor_root: Path) -> dict:
     """Retrive the environment as it stands, including defaults and substitutions, from Tutor."""
     return tutor.config.load(tutor_root)
 
-def generate_scaffold(tutor_root: Path) -> dict:
+
+def tutor_scaffold(tutor_root: Path) -> dict:
     """Generate a complete dictionary of config values with no variables set.
-    
+
     Keys have their existing values "hinted".
     """
-    return {
-        k: format_unset(v) for k, v in get_complete(tutor_root).items()
-    }
+    return {k: format_unset(v) for k, v in get_complete(tutor_root).items()}
+
+def update_config(tutor_root: Path, settings: dict) -> None:
+    tutor.config.save_config_file(tutor_root, tutor.config.merge(settings, get_complete()))

--- a/tutor_recon/config/tutor.py
+++ b/tutor_recon/config/tutor.py
@@ -18,13 +18,15 @@ def get_current(tutor_root: Path) -> dict:
     """Retrieve all Tutor configuration values which are currently set."""
     return tutor.config.load_current(tutor_root, defaults=get_defaults())
 
-def current_as_vjson(tutor_root: Path) -> dict:
-    """Generate a complete dictionary of config values, with set values set, and unset values marked as such."""
-    ret = {
-        k: format_unset(v) for k, v in get_defaults()
+def get_complete(tutor_root: Path) -> dict:
+    """Retrive the environment as it stands, including defaults and substitutions, from Tutor."""
+    return tutor.config.load(tutor_root)
+
+def generate_scaffold(tutor_root: Path) -> dict:
+    """Generate a complete dictionary of config values with no variables set.
+    
+    Keys have their existing values "hinted".
+    """
+    return {
+        k: format_unset(v) for k, v in get_complete(tutor_root).items()
     }
-    current_escaped = {
-        k: escape(v) for k, v in get_current(tutor_root)
-    }
-    ret.update(current_escaped)
-    return ret

--- a/tutor_recon/config/tutor.py
+++ b/tutor_recon/config/tutor.py
@@ -2,11 +2,11 @@
 
 from pathlib import Path
 
-import tutor
-from tutor.config import load_no_check, save_config_file, merge 
+from tutor.config import load_no_check, save_config_file, merge
 from tutor.config import load_all as tutor_load_all
 
 from tutor_recon.util.vjson import format_unset
+
 
 def load_all(tutor_root: Path) -> dict:
     """Retrive a tuple of (defaults, current_settings) from tutor."""
@@ -46,6 +46,4 @@ def tutor_scaffold(tutor_root: Path) -> dict:
 def update_config(tutor_root: Path, settings: dict) -> None:
     current = get_current(tutor_root)
     merge(settings, current)
-    save_config_file(
-        tutor_root, current
-    )
+    save_config_file(tutor_root, current)

--- a/tutor_recon/config/tutor.py
+++ b/tutor_recon/config/tutor.py
@@ -3,13 +3,20 @@
 from pathlib import Path
 
 import tutor
+from tutor.config import load_no_check, save_config_file, merge 
+from tutor.config import load_all as tutor_load_all
 
-from tutor_recon.util.vjson import escape, format_unset
+from tutor_recon.util.vjson import format_unset
+
+def load_all(tutor_root: Path) -> dict:
+    """Retrive a tuple of (defaults, current_settings) from tutor."""
+    return tutor_load_all(tutor_root.resolve())
 
 
-def get_defaults() -> dict:
+def get_defaults(tutor_root: Path) -> dict:
     """Retrieve the default tutor configuration settings, unexpanded."""
-    return tutor.config.load_defaults()
+    _, defaults = load_all(tutor_root)
+    return defaults
 
 
 def get_possible_keys() -> "list[str]":
@@ -19,12 +26,13 @@ def get_possible_keys() -> "list[str]":
 
 def get_current(tutor_root: Path) -> dict:
     """Retrieve all Tutor configuration values which are currently set."""
-    return tutor.config.load_current(tutor_root, defaults=get_defaults())
+    current, _ = load_all(tutor_root)
+    return current
 
 
 def get_complete(tutor_root: Path) -> dict:
     """Retrive the environment as it stands, including defaults and substitutions, from Tutor."""
-    return tutor.config.load(tutor_root)
+    return load_no_check(tutor_root)
 
 
 def tutor_scaffold(tutor_root: Path) -> dict:
@@ -36,6 +44,8 @@ def tutor_scaffold(tutor_root: Path) -> dict:
 
 
 def update_config(tutor_root: Path, settings: dict) -> None:
-    tutor.config.save_config_file(
-        tutor_root, tutor.config.merge(settings, get_complete())
+    current = get_current(tutor_root)
+    merge(settings, current)
+    save_config_file(
+        tutor_root, current
     )

--- a/tutor_recon/config/tutor.py
+++ b/tutor_recon/config/tutor.py
@@ -1,0 +1,30 @@
+"""Retrieve environment information from Tutor."""
+
+from pathlib import Path
+
+import tutor
+
+from tutor_recon.util.vjson import escape, format_unset
+
+def get_defaults() -> dict:
+    """Retrieve the default tutor configuration settings, unexpanded."""
+    return tutor.config.load_defaults()
+
+def get_possible_keys() -> 'list[str]':
+    """Retrieve all known possible Tutor configuration keys."""
+    return get_defaults().keys()
+
+def get_current(tutor_root: Path) -> dict:
+    """Retrieve all Tutor configuration values which are currently set."""
+    return tutor.config.load_current(tutor_root, defaults=get_defaults())
+
+def current_as_vjson(tutor_root: Path) -> dict:
+    """Generate a complete dictionary of config values, with set values set, and unset values marked as such."""
+    ret = {
+        k: format_unset(v) for k, v in get_defaults()
+    }
+    current_escaped = {
+        k: escape(v) for k, v in get_current(tutor_root)
+    }
+    ret.update(current_escaped)
+    return ret

--- a/tutor_recon/config/tutor.py
+++ b/tutor_recon/config/tutor.py
@@ -34,5 +34,8 @@ def tutor_scaffold(tutor_root: Path) -> dict:
     """
     return {k: format_unset(v) for k, v in get_complete(tutor_root).items()}
 
+
 def update_config(tutor_root: Path, settings: dict) -> None:
-    tutor.config.save_config_file(tutor_root, tutor.config.merge(settings, get_complete()))
+    tutor.config.save_config_file(
+        tutor_root, tutor.config.merge(settings, get_complete())
+    )

--- a/tutor_recon/config/tutor.py
+++ b/tutor_recon/config/tutor.py
@@ -44,6 +44,7 @@ def tutor_scaffold(tutor_root: Path) -> dict:
 
 
 def update_config(tutor_root: Path, settings: dict) -> None:
+    """Update the Tutor environment with the given new settings."""
     current = get_current(tutor_root)
     merge(settings, current)
     save_config_file(tutor_root, current)

--- a/tutor_recon/plugin.py
+++ b/tutor_recon/plugin.py
@@ -1,6 +1,7 @@
 import json
 import os
-from tutor_recon.config.tutor import generate_scaffold
+from tutor_recon.config.main import scaffold_all
+from tutor_recon.config.tutor import tutor_scaffold
 from tutor_recon.util.cli import emit
 import pkg_resources
 from glob import glob
@@ -61,9 +62,7 @@ def init(context: cloup.Context, env_dir=None, reset_location=False):
         emit(f"Set the new environment overrides location to {recon_root}.")
     else:
         recon_root = overrides_path(tutor_root=tutor_root, env_dir=env_dir).resolve()
-    scaffold = generate_scaffold(tutor_root)
-    scaffold_formatted = json.dumps(scaffold, indent=4)
-    emit(scaffold_formatted)
+    scaffold_all(tutor_root, recon_root)
     emit(
         f"You're all set! Your environment overrides can be configured at '{recon_root}'."
     )

--- a/tutor_recon/plugin.py
+++ b/tutor_recon/plugin.py
@@ -1,4 +1,6 @@
+import json
 import os
+from tutor_recon.config.tutor import generate_scaffold
 from tutor_recon.util.cli import emit
 import pkg_resources
 from glob import glob
@@ -59,7 +61,9 @@ def init(context: cloup.Context, env_dir=None, reset_location=False):
         emit(f"Set the new environment overrides location to {recon_root}.")
     else:
         recon_root = overrides_path(tutor_root=tutor_root, env_dir=env_dir).resolve()
-    safe_scaffold_env(recon_root)
+    scaffold = generate_scaffold(tutor_root)
+    scaffold_formatted = json.dumps(scaffold, indent=4)
+    emit(scaffold_formatted)
     emit(
         f"You're all set! Your environment overrides can be configured at '{recon_root}'."
     )

--- a/tutor_recon/plugin.py
+++ b/tutor_recon/plugin.py
@@ -1,15 +1,9 @@
 import os
-from tutor_recon.config.main import override_all, scaffold_all
-from tutor_recon.util.cli import emit
 import pkg_resources
 from glob import glob
-from pathlib import Path
 
-import click
-import cloup
-
-from tutor_recon.util.paths import overrides_path
 from tutor_recon.__about__ import __version__
+from tutor_recon.commands.recon import recon
 
 templates = pkg_resources.resource_filename("tutor_recon", "templates")
 
@@ -29,53 +23,4 @@ def patches():
     return all_patches
 
 
-@cloup.group(
-    help="Allows overriding and rendering settings, files, and templates (in their entirety) from a central location."
-)
-def recon():
-    pass
-
-
 command = recon
-
-
-@recon.command(help="Initialize recon.")
-@cloup.option(
-    "--env-dir",
-    help="The path to where your environment override files should (or already do) reside.",
-    type=cloup.Path(file_okay=False, path_type=Path),
-    default=None,
-)
-@cloup.option(
-    "--reset-location",
-    help="Reset the environment overrides directory location to default (has no effect if the directory is already in the default location).",
-    is_flag=True,
-)
-@cloup.pass_obj
-def init(context: cloup.Context, env_dir=None, reset_location=False):
-    tutor_root = Path(context.root)
-    if reset_location:
-        overrides_path(tutor_root=tutor_root).unlink(missing_ok=True)
-        recon_root = overrides_path(tutor_root=tutor_root)
-        emit(f"Set the new environment overrides location to {recon_root}.")
-    else:
-        recon_root = overrides_path(tutor_root=tutor_root, env_dir=env_dir).resolve()
-    scaffold_all(tutor_root, recon_root)
-    emit(
-        f"You're all set! Your environment overrides can be configured at '{recon_root}'."
-    )
-
-
-@recon.command(help="Echo the location of the config overrides directory over stdout.")
-@cloup.pass_obj
-def printroot(context: cloup.Context):
-    tutor_root = Path(context.root)
-    click.echo(overrides_path(tutor_root).resolve())
-
-
-@recon.command(help="Apply all override settings to the rendered environment.")
-@cloup.pass_obj
-def save(context: cloup.Context):
-    tutor_root = Path(context.root)
-    recon_root = overrides_path(tutor_root).resolve()
-    override_all(tutor_root, recon_root)

--- a/tutor_recon/plugin.py
+++ b/tutor_recon/plugin.py
@@ -55,9 +55,11 @@ def init(context: cloup.Context, env_dir=None, reset_location=False):
     tutor_root = Path(context.root)
     if reset_location:
         overrides_path(tutor_root=tutor_root).unlink(missing_ok=True)
-        new_path = overrides_path(tutor_root=tutor_root)
-        emit(f"Done. You can now configure your project at {new_path}.")
-    recon_root = overrides_path(tutor_root=tutor_root, env_dir=env_dir).resolve()
+        recon_root = overrides_path(tutor_root=tutor_root)
+        emit(f"Set the new environment overrides location to {recon_root}.")
+    else:
+        recon_root = overrides_path(tutor_root=tutor_root, env_dir=env_dir).resolve()
+    safe_scaffold_env(recon_root)
     emit(
         f"You're all set! Your environment overrides can be configured at '{recon_root}'."
     )

--- a/tutor_recon/plugin.py
+++ b/tutor_recon/plugin.py
@@ -1,7 +1,5 @@
-import json
 import os
-from tutor_recon.config.main import scaffold_all
-from tutor_recon.config.tutor import tutor_scaffold
+from tutor_recon.config.main import override_all, scaffold_all
 from tutor_recon.util.cli import emit
 import pkg_resources
 from glob import glob
@@ -72,4 +70,12 @@ def init(context: cloup.Context, env_dir=None, reset_location=False):
 @cloup.pass_obj
 def printroot(context: cloup.Context):
     tutor_root = Path(context.root)
-    click.echo(overrides_path(tutor_root=tutor_root).resolve())
+    click.echo(overrides_path(tutor_root).resolve())
+
+
+@recon.command(help="Apply all override settings to the rendered environment.")
+@cloup.pass_obj
+def save(context: cloup.Context):
+    tutor_root = Path(context.root)
+    recon_root = overrides_path(tutor_root).resolve()
+    override_all(tutor_root, recon_root)

--- a/tutor_recon/plugin.py
+++ b/tutor_recon/plugin.py
@@ -1,8 +1,14 @@
-from glob import glob
 import os
+from tutor_recon.util.cli import emit
 import pkg_resources
+from glob import glob
+from pathlib import Path
 
-from .__about__ import __version__
+import click
+import cloup
+
+from tutor_recon.util.paths import overrides_path
+from tutor_recon.__about__ import __version__
 
 templates = pkg_resources.resource_filename("tutor_recon", "templates")
 
@@ -20,3 +26,45 @@ def patches():
             content = patch_file.read()
             all_patches[name] = content
     return all_patches
+
+
+@cloup.group(
+    help="Allows overriding and rendering settings, files, and templates (in their entirety) from a central location."
+)
+def recon():
+    pass
+
+
+command = recon
+
+
+@recon.command(help="Initialize recon.")
+@cloup.option(
+    "--env-dir",
+    help="The path to where your environment override files should (or already do) reside.",
+    type=cloup.Path(file_okay=False, path_type=Path),
+    default=None,
+)
+@cloup.option(
+    "--reset-location",
+    help="Reset the environment overrides directory location to default (has no effect if the directory is already in the default location).",
+    is_flag=True,
+)
+@cloup.pass_obj
+def init(context: cloup.Context, env_dir=None, reset_location=False):
+    tutor_root = Path(context.root)
+    if reset_location:
+        overrides_path(tutor_root=tutor_root).unlink(missing_ok=True)
+        new_path = overrides_path(tutor_root=tutor_root)
+        emit(f"Done. You can now configure your project at {new_path}.")
+    recon_root = overrides_path(tutor_root=tutor_root, env_dir=env_dir).resolve()
+    emit(
+        f"You're all set! Your environment overrides can be configured at '{recon_root}'."
+    )
+
+
+@recon.command(help="Echo the location of the config overrides directory over stdout.")
+@cloup.pass_obj
+def printroot(context: cloup.Context):
+    tutor_root = Path(context.root)
+    click.echo(overrides_path(tutor_root=tutor_root).resolve())

--- a/tutor_recon/util/cli.py
+++ b/tutor_recon/util/cli.py
@@ -3,7 +3,7 @@
 from typing import Any, IO, Optional
 import click
 
-PLUGIN_STYLED = click.style("recon", fg="blue")
+PLUGIN_STYLED = click.style("recon", fg="magenta")
 PLUGIN_TAG = f"[{PLUGIN_STYLED}]"
 
 

--- a/tutor_recon/util/cli.py
+++ b/tutor_recon/util/cli.py
@@ -1,0 +1,23 @@
+"""Utilities for working with command-line output."""
+
+from typing import Any, IO, Optional
+import click
+
+PLUGIN_STYLED = click.style("recon", fg="blue")
+PLUGIN_TAG = f"[{PLUGIN_STYLED}]"
+
+
+def emit(
+    message: Optional[Any] = "",
+    file: Optional[IO] = None,
+    nl: bool = True,
+    err: bool = False,
+    color: Optional[bool] = None,
+) -> None:
+    """Emit the given string, prefixed with the library's name.
+
+    Additional keywords are identical to `click.echo()`.
+    """
+    return click.echo(
+        message=f"{PLUGIN_TAG} {message}", file=file, nl=nl, err=err, color=color
+    )

--- a/tutor_recon/util/misc.py
+++ b/tutor_recon/util/misc.py
@@ -1,0 +1,57 @@
+"""Miscellaneous utility functions."""
+
+from typing import Any, Iterator, Optional
+from collections.abc import Mapping, Sequence
+
+
+def brief(string: str, max_len=20) -> str:
+    """Shorten the given string to a maximum length using elipses."""
+    if len(string) > max_len:
+        return string[: max_len - 3] + "..."
+    return string
+
+
+def walk_dict(
+    mapping: Mapping, key_prefix: "Optional[Sequence[str]]" = None
+) -> "Iterator[tuple[Sequence[str], Any]]":
+    """Recursively walk through the given dict and yield all terminal values.
+
+    Descends into values which are dictionaries/mappings, but not lists.
+
+    Yields:
+        (key_sequence, value) where `key_sequence` is the sequence of nested keys in `mapping`
+        under which `value` resides.
+    """
+    for k, v in mapping.items():
+        key_seq = [k]
+        if key_prefix:
+            key_seq = key_prefix + key_seq
+        if isinstance(v, Mapping):
+            yield from walk_dict(v, key_prefix=key_seq)
+        else:
+            yield key_seq, v
+
+
+def set_nested(mapping: Mapping, key_sequence: "Sequence[str]", value: Any) -> None:
+    """Set the value in `mapping` under the given sequence of nested keys.
+
+    Sub-mappings are created as instances of the same type as `mapping` if they do not yet exist.
+    """
+    assert key_sequence, "The sequence of keys cannot be empty."
+    if len(key_sequence) == 1:
+        mapping[key_sequence[0]] = value
+    else:
+        first, rest = key_sequence[0], key_sequence[1:]
+        if first not in mapping:
+            mapping[first] = type(mapping)()
+        set_nested(mapping[first], rest, value)
+
+
+def recursive_update(mapping: Mapping, other: Mapping) -> None:
+    """Recursively update `mapping` using the terminal values from `other`.
+
+    Creates sub-mappings if they don't yet exist, but does not destroy existing
+    sub-mappings.
+    """
+    for key_list, value in walk_dict(other):
+        set_nested(mapping, key_list, value)

--- a/tutor_recon/util/misc.py
+++ b/tutor_recon/util/misc.py
@@ -1,6 +1,6 @@
 """Miscellaneous utility functions."""
 
-from typing import Any, Iterator, Optional
+from typing import Any, Iterator, MutableMapping, Optional
 from collections.abc import Mapping, Sequence
 
 
@@ -55,3 +55,29 @@ def recursive_update(mapping: Mapping, other: Mapping) -> None:
     """
     for key_list, value in walk_dict(other):
         set_nested(mapping, key_list, value)
+
+class WrappedDict(MutableMapping):
+    """Dict-like object which thinly wraps an underlying dictionary.
+    
+    Does *not* satisfy `isinstance(WrappedDict, dict)` -- this is intentional.
+    It allows customization of serialization by `json.dump()` and `json.dumps()`,
+    since `json` calls a `default` function on unknown types.
+    """
+    def __init__(self, *args, **kwargs):
+        self._dict = dict()
+        self.update(dict(*args, **kwargs))
+
+    def __getitem__(self, key):
+        return self._dict[key]
+
+    def __setitem__(self, key, value):
+        self._dict[key] = value
+
+    def __delitem__(self, key):
+        del self._dict[key]
+
+    def __iter__(self):
+        return iter(self._dict)
+    
+    def __len__(self):
+        return len(self._dict)

--- a/tutor_recon/util/misc.py
+++ b/tutor_recon/util/misc.py
@@ -56,13 +56,15 @@ def recursive_update(mapping: Mapping, other: Mapping) -> None:
     for key_list, value in walk_dict(other):
         set_nested(mapping, key_list, value)
 
+
 class WrappedDict(MutableMapping):
     """Dict-like object which thinly wraps an underlying dictionary.
-    
+
     Does *not* satisfy `isinstance(WrappedDict, dict)` -- this is intentional.
     It allows customization of serialization by `json.dump()` and `json.dumps()`,
     since `json` calls a `default` function on unknown types.
     """
+
     def __init__(self, *args, **kwargs):
         self._dict = dict()
         self.update(dict(*args, **kwargs))
@@ -78,6 +80,6 @@ class WrappedDict(MutableMapping):
 
     def __iter__(self):
         return iter(self._dict)
-    
+
     def __len__(self):
         return len(self._dict)

--- a/tutor_recon/util/paths.py
+++ b/tutor_recon/util/paths.py
@@ -1,0 +1,38 @@
+"""Path-related utilities."""
+
+from pathlib import Path
+from typing import Optional, Union
+
+import click
+
+
+def set_overrides_path(tutor_root: Path, new_path: Path) -> Path:
+    """Store a string representation of `new_path` in `tutor_root / '.recon'`.
+
+    Returns:
+        The value of `new_path`.
+    """
+    new_path_str = str(new_path.resolve())
+    with open(tutor_root / ".recon", "w") as f:
+        f.write(new_path_str)
+    return new_path
+
+
+def overrides_path(tutor_root: Path, env_dir: Optional[Path] = None) -> Path:
+    """Get the correct path to the override configuration.
+
+    If `env_dir` is provided, store that path and return it.
+    Otherwise, either
+        - use the value in the existing `.recon` file if it exists, or
+        - create a new `.recon` file, then store and return
+          `tutor_root / 'env_overrides'` as the default value.
+    """
+    tutor_root = Path(tutor_root)
+    recon_file = tutor_root / ".recon"
+    if env_dir:
+        return set_overrides_path(tutor_root, env_dir)
+    if recon_file.exists():
+        with click.open_file(recon_file, "r") as f:
+            custom_path = f.read()
+        return Path(custom_path)
+    return set_overrides_path(tutor_root, tutor_root / "env_overrides")

--- a/tutor_recon/util/paths.py
+++ b/tutor_recon/util/paths.py
@@ -1,9 +1,10 @@
 """Path-related utilities."""
 
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional
 
 import click
+import cloup
 
 
 def set_overrides_path(tutor_root: Path, new_path: Path) -> Path:
@@ -36,3 +37,8 @@ def overrides_path(tutor_root: Path, env_dir: Optional[Path] = None) -> Path:
             custom_path = f.read()
         return Path(custom_path)
     return set_overrides_path(tutor_root, tutor_root / "env_overrides")
+
+
+def root_dirs(context: cloup.Context) -> "tuple[Path, Path]":
+    """Return (tutor_root, recon_root) as determined using the given `Context`."""
+    return Path(context.obj.root), overrides_path(context.obj.root)

--- a/tutor_recon/util/string.py
+++ b/tutor_recon/util/string.py
@@ -1,0 +1,7 @@
+"""String-related utilities."""
+
+def brief(string: str, max_len=20) -> str:
+    """Shorten the given string to a maximum length using elipses."""
+    if len(string) > max_len:
+        return string[:max_len - 3] + '...'
+    return string

--- a/tutor_recon/util/string.py
+++ b/tutor_recon/util/string.py
@@ -1,8 +1,0 @@
-"""String-related utilities."""
-
-
-def brief(string: str, max_len=20) -> str:
-    """Shorten the given string to a maximum length using elipses."""
-    if len(string) > max_len:
-        return string[: max_len - 3] + "..."
-    return string

--- a/tutor_recon/util/string.py
+++ b/tutor_recon/util/string.py
@@ -1,7 +1,8 @@
 """String-related utilities."""
 
+
 def brief(string: str, max_len=20) -> str:
     """Shorten the given string to a maximum length using elipses."""
     if len(string) > max_len:
-        return string[:max_len - 3] + '...'
+        return string[: max_len - 3] + "..."
     return string

--- a/tutor_recon/util/vjson.py
+++ b/tutor_recon/util/vjson.py
@@ -1,10 +1,11 @@
 """A custom JSON decoder and associated utilities."""
 
 from json import JSONDecoder
+import json
+from json.decoder import JSONDecodeError
 from pathlib import Path
 from tutor_recon.util.string import brief
-from typing import TypeVar, Union
-from enum import Enum
+from typing import Any, TypeVar
 
 MARKER = "$"
 ESCAPED_MARKER = MARKER * 2
@@ -12,6 +13,9 @@ UNSET_CONST_NAME = "default"
 
 JSON_T = TypeVar("JSON_T", str, int, float, bool, list, dict)
 """A type which can be represented in JSON."""
+
+NOT_SET = object()
+"""Indicates that a value is not set."""
 
 
 def escape(value: JSON_T = None) -> JSON_T:
@@ -30,6 +34,10 @@ def format_unset(default: JSON_T, include_default=True, max_default_len=35) -> s
         default = brief(repr(default), max_len=max_default_len)
         return f"${UNSET_CONST_NAME} ({default})"
     return f"${UNSET_CONST_NAME}"
+
+
+def raise_decode_error(msg: str) -> None:
+    raise JSONDecodeError(msg)
 
 
 class VJSONDecoder(JSONDecoder):
@@ -58,23 +66,98 @@ class VJSONDecoder(JSONDecoder):
     """
 
     def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, object_hook=self.object_hook, **kwargs)
         self._csm = {
-            ESCAPED_MARKER: lambda _: "$",
-            MARKER + "/": self.expand_absolute,
+            ESCAPED_MARKER: lambda token, **_: token[1:],
+            f"{MARKER}.": lambda *args, **kwargs: raise_decode_error(
+                "This decoder does not support relative path references."
+            ),
+            f"{MARKER}/": self.expand_absolute,
             MARKER: self.handle_variable,
         }  # Stands for "control sequence mapping".
 
-    @classmethod
-    def fs_aware_decoder(cls, location: Path, *args, **kwargs) -> "VJSONDecoder":
-        """Create an instance which supports both path control sequences."""
-        instance = cls(*args, **kwargs)
-        instance._csm[MARKER + "."] = lambda pair: instance.expand_relative(
-            pair, location
-        )
-        return instance
+    def expand_absolute(self, value, key=NOT_SET):
+        """Load the absolute path given in `value`. The path cannot be in the key.
 
-    @classmethod
-    def simple_decoder(cls, *args, **kwargs) -> "VJSONDecoder":
-        """Create an instance which only supports absolute path expansion."""
-        return cls(*args, **kwargs)
+        It is an error to set `key`. The file pointed to at `value` is assumed to be a
+        .v.json-formatted text file.
+        """
+        assert key is NOT_SET
+        with open(value, "r") as f:
+            return json.load(f, cls=VJSONDecoder)
+
+    def expand_relative_to(self, location, value, key=NOT_SET):
+        """Load the path given in `value` relative to `location`. The path cannot be in the key.
+
+        It is an error to set `key`. The file pointed to at `location / value` is assumed to be
+        a .v.json-formatted text file.
+        """
+        assert key is NOT_SET
+        with open(location / value, "r") as f:
+            return json.load(f, cls=VJSONDecoder)
+
+    def expand_escaped(self, value, key=NOT_SET):
+        """Remove the escape character from the `key` if set, or from the `value` not."""
+        if key is NOT_SET:
+            return value[1:]
+        return key[1:]
+
+    def handle_variable(self, value, key=NOT_SET):
+        """Store a value under `key` if `key` is set, otherwise handle a reference in `value`.
+
+        In other words:
+        - If `key` is set, `value` is stored under `key` so it can later be referenced.
+          `key` is then returned.
+        - If `key` is not set, expand the variable reference in in `value` and return the result
+          of the expansion.
+
+        If key is not set and value is `$default`, return NOT_SET.
+        """
+        if key is NOT_SET:
+            if value.startswith(f'{MARKER}{UNSET_CONST_NAME}'):
+                return NOT_SET
+            return self._env[value]
+        self._env[key] = value
+        return key
+
+    def expand(self, pair: "tuple[str, Any]") -> "tuple[str, Any]":
+        """Expand the (key, value) pair as appropriate.
+
+        First expands the key, then the value.
+        """
+        k, v = pair
+        k2, v2 = k[:2], v[:2]
+        k1, v1 = k[:1], v[:1]
+        if k2 in self._csm:
+            k = self._csm[k2](v, key=k)
+        elif k1 in self._csm:
+            k = self._csm[k1](v, key=k)
+        if isinstance(v, str):
+            if v2 in self._csm:
+                v = self._csm[v2](v)
+            elif v1 in self._csm:
+                v = self._csm[v1](v)
+        elif isinstance(v, dict):
+            v = self.object_hook(v)
+        return k, v
+
+    def object_hook(self, obj: dict) -> dict:
+        gen_expanded = (self.expand(pair) for pair in obj.items())
+        return {k: v for k, v in gen_expanded if v is not NOT_SET}
+
+
+def relative_decoder(location: Path) -> type:
+
+    class FSAwareVJSONDecoder(VJSONDecoder):
+        f"""A VJSONDecoder which supports relative file references relative to '{location}'."""
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            
+            def expand_relative(path, **closure_kwargs):
+                f"""Closure which expands the given path relative to '{location}'."""
+                return self.expand_relative_to(location, path, **closure_kwargs)
+            
+            self._csm[MARKER + "."] = expand_relative
+
+    return FSAwareVJSONDecoder    
+

--- a/tutor_recon/util/vjson.py
+++ b/tutor_recon/util/vjson.py
@@ -311,7 +311,7 @@ def dumps(
     expand_remote_mappings: bool = False,
     indent: Optional[int] = 4,
     **kwargs,
-) -> None:
+) -> str:
     """Dump the given object as a VJSON-formatted string."""
     return json.dumps(
         obj,

--- a/tutor_recon/util/vjson.py
+++ b/tutor_recon/util/vjson.py
@@ -1,7 +1,68 @@
 """A custom JSON decoder and associated utilities."""
 
 from json import JSONDecoder
+from pathlib import Path
+import typing
 
+MARKER = '$'
+ESCAPED_MARKER = MARKER * 2
+
+JSON_T = typing.TypeVar('JSON_T', str, int, float, bool, list, dict)
+"""A type which can be represented in JSON."""
+
+def escape(value: JSON_T) -> JSON_T:
+    """If the value is a string beginning with '$', replace it with '$$'.
+    
+    Does not recursively descend into child objects.
+    """
+    if isinstance(value, str) and value.startswith('$'):
+        return '$' + value
+    return value
+
+def format_unset(default: JSON_T = None) -> str:
+    """Return '$unset' with a parenthesized default value added after a space."""
+    return f'$unset ({default!r})'
 
 class VJSONDecoder(JSONDecoder):
-    """A custom JSON decoder which supports variable expansion along with references to objects in other files."""
+    """A custom JSON decoder which supports variable expansion along with references to objects in other files.
+    
+    Control sequences must occur at the beginning of an encoded string (key or value), 
+        and are defined as follows:
+
+    `$$`: A single `$` character.
+    `$.`: Denotes the beginning of a relative path to anothor .json or .v.json spec to be substituted in its place.
+          Always evaluates to an object.
+    `$/`: Similar to above, but with an absolute path.
+    `$` : Signifies the beginning of a variable name. 
+          If given as a key, it is added along with its corresponding value to the rendering namespace.
+          If given as a value, it is expanded to the corresponding value in the rendering namespace.
+
+    Two-character control sequences are checked before one-character control sequences.
+
+    A special built-in variable, `$unset`, when given as a value (optionally followed by any sequence of characters,
+    which are ignored), signifies that a keypair should be entirely ignored by the decoder. 
+    
+    Providing `$unset`, or either path sequence, as a key is an error.
+
+    The class can be instantiated with or without support for the relative path control sequence.
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._csm = {
+            ESCAPED_MARKER: lambda _: '$',
+            MARKER + '/': self.expand_absolute,
+            MARKER: self.handle_variable,
+        }  # Stands for "control sequence mapping".
+
+    @classmethod
+    def fs_aware_decoder(cls, location: Path, *args, **kwargs) -> 'VJSONDecoder':
+        """Create an instance which supports both path control sequences."""
+        instance = cls(*args, **kwargs)
+        instance._csm[MARKER + '.'] = lambda pair: instance.expand_relative(pair, location)
+        return instance
+
+    @classmethod
+    def simple_decoder(cls, *args, **kwargs) -> 'VJSONDecoder':
+        """Create an instance which only supports absolute path expansion."""
+        return cls(*args, **kwargs)

--- a/tutor_recon/util/vjson.py
+++ b/tutor_recon/util/vjson.py
@@ -1,0 +1,7 @@
+"""A custom JSON decoder and associated utilities."""
+
+from json import JSONDecoder
+
+
+class VJSONDecoder(JSONDecoder):
+    """A custom JSON decoder which supports variable expansion along with references to objects in other files."""

--- a/tutor_recon/util/vjson.py
+++ b/tutor_recon/util/vjson.py
@@ -99,8 +99,8 @@ class VJSONDecoder(JSONDecoder):
         and are defined as follows:
 
     `$$`: A single `$` character. Valid as either a key or value.
-    `$.`: Denotes the beginning of a relative path to anothor .json or .v.json spec to be substituted in its place.
-          Always evaluates to an object. Valid only as a value.
+    `$.`: Denotes the beginning of a relative path to anothor .json or .v.json spec whose contents are to be substituted 
+          in its place. Valid only as a value.
     `$/`: Similar to above, but with an absolute path. Valid only as a value.
     `$-`: When given as a value, optionally followed by any sequence of characters (which is ignored), signifies that
           a keypair should be entirely ignored by the decoder.

--- a/tutor_recon/util/vjson.py
+++ b/tutor_recon/util/vjson.py
@@ -6,49 +6,52 @@ from tutor_recon.util.string import brief
 from typing import TypeVar, Union
 from enum import Enum
 
-MARKER = '$'
+MARKER = "$"
 ESCAPED_MARKER = MARKER * 2
-UNSET_CONST_NAME = 'default'
+UNSET_CONST_NAME = "default"
 
-JSON_T = TypeVar('JSON_T', str, int, float, bool, list, dict)
+JSON_T = TypeVar("JSON_T", str, int, float, bool, list, dict)
 """A type which can be represented in JSON."""
 
 
 def escape(value: JSON_T = None) -> JSON_T:
     """If the value is a string beginning with '$', replace it with '$$'.
-    
+
     Does not recursively descend into child objects.
     """
-    if isinstance(value, str) and value.startswith('$'):
-        return '$' + value
+    if isinstance(value, str) and value.startswith("$"):
+        return "$" + value
     return value
 
-def format_unset(default: JSON_T, include_default = True, max_default_len=35) -> str:
+
+def format_unset(default: JSON_T, include_default=True, max_default_len=35) -> str:
     """Return '$default' with a parenthesized default value optionally added after a space."""
     if include_default:
         default = brief(repr(default), max_len=max_default_len)
-        return f'${UNSET_CONST_NAME} ({default})'
-    return f'${UNSET_CONST_NAME}'
+        return f"${UNSET_CONST_NAME} ({default})"
+    return f"${UNSET_CONST_NAME}"
+
 
 class VJSONDecoder(JSONDecoder):
     """A custom JSON decoder which supports variable expansion along with references to objects in other files.
-    
-    Control sequences must occur at the beginning of an encoded string (key or value), 
+
+    Control sequences must occur at the beginning of an encoded string (key or value),
         and are defined as follows:
 
     `$$`: A single `$` character.
     `$.`: Denotes the beginning of a relative path to anothor .json or .v.json spec to be substituted in its place.
           Always evaluates to an object.
     `$/`: Similar to above, but with an absolute path.
-    `$` : Signifies the beginning of a variable name. 
+    `$` : Signifies the beginning of a variable name.
           If given as a key, it is added along with its corresponding value to the rendering namespace.
           If given as a value, it is expanded to the corresponding value in the rendering namespace.
 
-    Two-character control sequences are checked before one-character control sequences.
+    Two-character control sequences are checked before one-character control sequences, and keys are substituted before
+    values.
 
     A special built-in variable, `$default`, when given as a value (optionally followed by any sequence of characters,
-    which are ignored), signifies that a keypair should be entirely ignored by the decoder. 
-    
+    which are ignored), signifies that a keypair should be entirely ignored by the decoder.
+
     Providing `$default`, or either path sequence, as a key is an error.
 
     The class can be instantiated with or without support for the relative path control sequence.
@@ -57,19 +60,21 @@ class VJSONDecoder(JSONDecoder):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self._csm = {
-            ESCAPED_MARKER: lambda _: '$',
-            MARKER + '/': self.expand_absolute,
+            ESCAPED_MARKER: lambda _: "$",
+            MARKER + "/": self.expand_absolute,
             MARKER: self.handle_variable,
         }  # Stands for "control sequence mapping".
 
     @classmethod
-    def fs_aware_decoder(cls, location: Path, *args, **kwargs) -> 'VJSONDecoder':
+    def fs_aware_decoder(cls, location: Path, *args, **kwargs) -> "VJSONDecoder":
         """Create an instance which supports both path control sequences."""
         instance = cls(*args, **kwargs)
-        instance._csm[MARKER + '.'] = lambda pair: instance.expand_relative(pair, location)
+        instance._csm[MARKER + "."] = lambda pair: instance.expand_relative(
+            pair, location
+        )
         return instance
 
     @classmethod
-    def simple_decoder(cls, *args, **kwargs) -> 'VJSONDecoder':
+    def simple_decoder(cls, *args, **kwargs) -> "VJSONDecoder":
         """Create an instance which only supports absolute path expansion."""
         return cls(*args, **kwargs)

--- a/tutor_recon/util/vjson.py
+++ b/tutor_recon/util/vjson.py
@@ -123,7 +123,7 @@ class VJSONDecoder(JSONDecoder):
 
     def object_hook(self, obj: dict) -> dict:
         gen_expanded = (self.expand(pair) for pair in obj.items())
-        return {k: v for k, v in gen_expanded if v is not NOTHING}
+        return {k: v for k, v in gen_expanded if v is not IGNORE}
 
     def expand_default(self, value: JSON_T, key: KEY_T = NOTHING) -> IGNORE_T:
         """Return `IGNORE`."""


### PR DESCRIPTION
## Overview

This PR adds support for applying overrides for values in three common settings files:

- `$(tutor config printroot)/config.yml` (Tutor's own settings)
- `$(tutor config printroot)/envs/apps/openedx/config/cms.env.json` (Edx CMS settings)
- `$(tutor config printroot)/envs/apps/openedx/config/lms.env.json` (Edx LMS settings)


## Commands

To accomplish this, several sub-commands were added to `tutor recon`:

| Sub-Command | Description                                                                                                                                                                                   |
| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `init`      | First run `tutor config save`, then create a directory in which recon will store settings override values. Finally, store the location of this directory at `$(tutor config printroot)/.recon. |
| `printroot` | Echo the location of recon's settings override directory over stdout.                                                                                                                         |
| `save`      | First run `tutor config save`, then apply all overrides to the tutor environment.                                                                                                             |


## Implementation

### VJSON

Settings overrides are provided using a simple JSON dialect termed "VJSON". VJSON files are valid JSON files, but support a couple of additional features via two-character "control sequences" which may appear at the beginning of any string within the JSON file. The "V" initially stood for "**v**ariable expansion". Serializing and parsing data in this format is implemented through custom subclasses of the `json.JSONEncoder` and `json.JSONDecoder` types in Python's standard library. The available control sequences are defined as follows:

| Control Sequence | Description                                                                                                 |
| ---------------- | ----------------------------------------------------------------------------------------------------------- |
| `$$`             | Expands to a single `"$"` character (a doubling-escape).                                                    |
| `$/`             | Expands to the contents of the JSON/VJSON file stored at the absolute path which follows the `/` character. |
| `$.`             | Same as `$/`, but uses a relative path.                                                                     |
| `$-`             | Explicitly indicates that a value is not set.*                                                              |

*This is different than `null` -- when `$-` appears as a value, it indicates that no override is set at all, so whatever value already exists should be left alone (whereas `null` would indicate that the existing value should be overwritten with the value `null` -- a very different outcome!).

#### Rationale

My goal here is to make all possible OpenEdx platform configuration settings

- visible, so that the possible configuration changes available to the developer is made obvious,
- clean, so that the settings file is not so large as to be too difficult to comprehend by reading, and
- easy to experiment with, so tweaking settings during development takes as little time as possible.

YAML could have been used instead. However, my personal opinion is that YAML is unnecessarily difficult to read and write for this purpose: it's hard to tell what is a string and what isn't, the expansion notation looks a magical incantation, and I don't find the underlying structure of the data to be as immediately obvious as it is in a well-formatted JSON file. These are entirely personal opinions; YML has great use-cases. I just thought it was too much for what should be a simple set of a few data structuring features.
