### PR TITLE
Rework scaffolding logic.

### DIFF
--- a/tutor_recon/commands/recon.py
+++ b/tutor_recon/commands/recon.py
@@ -21,7 +21,7 @@ RECON_SAVE_STYLED = click.style("tutor recon save", fg="magenta")
 
 
 def run_tutor_config_save(context: cloup.Context) -> None:
-    emit(f"Running '{CONFIG_SAVE_STYLED}'.")
+    emit(f"Running {CONFIG_SAVE_STYLED}.")
     context.invoke(tutor_config_save)
 
 
@@ -51,9 +51,10 @@ def init(context: cloup.Context, env_dir, tutor):
     recon_root = overrides_path(tutor_root=tutor_root, env_dir=env_dir).resolve()
     if tutor:
         run_tutor_config_save(context)
-    scaffold_all(recon_root)
+    scaffold_all(tutor_root, recon_root)
+    recon_root_str = click.style(str(recon_root), fg="magenta")
     emit(
-        f"You're all set! Your environment overrides can be configured at '{recon_root}'."
+        f"You're all set! Your environment overrides can be configured at {recon_root_str} 👍"
     )
 
 
@@ -78,20 +79,21 @@ def save(context: cloup.Context, tutor):
         run_tutor_config_save(context)
     emit("Applying overrides.")
     override_all(tutor_root, recon_root)
+    emit("Done.")
 
 
 @recon.command(help="Scaffold an override of a tutor template in its entirety.")
 @cloup.argument("path")
 @cloup.pass_context
 def replace_template(context: cloup.Context, path: str):
-    _, recon_root = root_dirs(context)
+    tutor_root, recon_root = root_dirs(context)
     main = main_config(recon_root)
-    override = TemplateOverride.for_template(path, recon_root)
+    override = TemplateOverride.for_template(path)
     main.add_override(override)
-    override.scaffold(recon_root)
+    override.scaffold(tutor_root, recon_root)
     main.save(recon_root / "main.v.json")
     path_styled = click.style(str(path), fg="blue")
-    emit(f"Scaffolded {path_styled} at {Path(override.src).resolve()} 👍.")
+    emit(f"Scaffolded {path_styled} at {Path(override.src).resolve()} 👍")
     emit(
         f"Change the file to your heart's content, then it will be rendered when you run {RECON_SAVE_STYLED}."
     )

--- a/tutor_recon/config/main.py
+++ b/tutor_recon/config/main.py
@@ -14,26 +14,26 @@ DEFAULT_MAIN_CONFIG = json.dumps(
         "overrides": [
             {
                 "$t": "tutor",
-                "dest": "config.yml",
-                "src": "$./tutor_config.v.json",
+                "target": "config.yml",
+                "overrides": "$./tutor_config.v.json",
             },
             {
                 "$t": "json",
-                "dest": "env/apps/openedx/config/cms.env.json",
-                "src": "$./openedx/cms.env.v.json",
+                "target": "env/apps/openedx/config/cms.env.json",
+                "overrides": "$./openedx/cms.env.v.json",
             },
             {
                 "$t": "json",
-                "dest": "env/apps/openedx/config/lms.env.json",
-                "src": "$./openedx/lms.env.v.json",
+                "target": "env/apps/openedx/config/lms.env.json",
+                "overrides": "$./openedx/lms.env.v.json",
             },
         ],
     }
 )
 
 
-class MainConfig(vjson.VJSONSerializableMixin):
-    """Container object for `OverrideConfig` instances."""
+class MainConfig(OverrideMixin):
+    """Main container which includes all relevant override objects."""
 
     type_id = "main"
 
@@ -61,6 +61,11 @@ class MainConfig(vjson.VJSONSerializableMixin):
         )
         return ret
 
+    def scaffold(self, tutor_root: Path, recon_root: Path) -> None:
+        for override in self.overrides:
+            override.scaffold(tutor_root, recon_root)
+        self.save(to=recon_root / "main.v.json")
+
     def add_override(self, override: OverrideMixin) -> None:
         self.overrides.append(override)
 
@@ -77,8 +82,8 @@ def main_config(recon_root: Path) -> MainConfig:
     return MainConfig.default(recon_root)
 
 
-def scaffold_all(recon_root: str) -> None:
-    main_config(recon_root).save(Path(recon_root / "main.v.json"))
+def scaffold_all(tutor_root: Path, recon_root: Path) -> None:
+    main_config(recon_root).scaffold(tutor_root, recon_root)
 
 
 def override_all(tutor_root: str, recon_root: str) -> None:

--- a/tutor_recon/config/override.py
+++ b/tutor_recon/config/override.py
@@ -1,31 +1,21 @@
-"""Mixin for objects which can aplly overrides to the Tutor environment."""
-from abc import ABC, abstractmethod
+"""Mixin for objects which can apply overrides to the Tutor environment."""
+from abc import abstractmethod
 from pathlib import Path
-from typing import Optional
 
 from tutor_recon.util import vjson
 
 
 class OverrideMixin(vjson.VJSONSerializableMixin):
-    def __init__(self, src: vjson.VJSON_T, dest: Path, **kwargs) -> None:
+    def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
-        self.src = src
-        self.dest = dest
 
     @abstractmethod
     def override(self, tutor_root: Path, recon_root: Path) -> None:
         """Apply this override to the tutor environment."""
 
-    def to_object(self) -> dict:
-        obj = super().to_object()
-        obj.update(
-            {
-                "src": self.src,
-                "dest": self.dest,
-            }
-        )
-        return obj
+    @abstractmethod
+    def scaffold(self, tutor_root: Path, recon_root: Path) -> None:
+        """Add any defaults and perform any necessary initialization for this object.
 
-    @classmethod
-    def from_object(cls, obj: dict) -> "vjson.VJSONSerializableMixin":
-        return cls(src=obj["src"], dest=obj["dest"])
+        Implementations should be idempotent.
+        """

--- a/tutor_recon/config/templates.py
+++ b/tutor_recon/config/templates.py
@@ -11,7 +11,9 @@ class TemplateOverride(OverrideMixin):
     type_id = "template"
 
     def __init__(self, src: vjson.VJSON_T, dest: Path, **kwargs) -> None:
-        super().__init__(src, dest, **kwargs)
+        super().__init__(**kwargs)
+        self.src = src
+        self.dest = dest
 
     def override(self, tutor_root: Path, recon_root: Path) -> None:
         """Render the template to the tutor environment."""
@@ -19,7 +21,7 @@ class TemplateOverride(OverrideMixin):
         dest_dir = tutor_root / "templates"
         render_template(source_path, dest_dir, tutor_root)
 
-    def scaffold(self, recon_root: Path) -> None:
+    def scaffold(self, tutor_root: Path, recon_root: Path) -> None:
         """Create the template override, initially identical to the tutor version.
 
         Does nothing if the template already exists.
@@ -34,13 +36,24 @@ class TemplateOverride(OverrideMixin):
         with open(recon_template_path, "w") as f:
             f.write(original_template)
 
+    def to_object(self) -> dict:
+        obj = super().to_object()
+        obj.update(
+            {
+                "src": self.src,
+                "dest": self.dest,
+            }
+        )
+        return obj
+
     @classmethod
-    def for_template(
-        cls, template_relpath: Path, recon_root: Path
-    ) -> "TemplateOverride":
-        """Construct and scaffold (if necessary) a TemplateOverride for the given tutor template."""
+    def from_object(cls, obj: dict) -> "vjson.VJSONSerializableMixin":
+        return cls(src=obj["src"], dest=obj["dest"])
+
+    @classmethod
+    def for_template(cls, template_relpath: Path) -> "TemplateOverride":
+        """Construct a TemplateOverride for the given tutor template."""
         instance = cls(
             src=str(Path("templates") / template_relpath), dest=str(template_relpath)
         )
-        instance.scaffold(recon_root)
         return instance

--- a/tutor_recon/config/tutor.py
+++ b/tutor_recon/config/tutor.py
@@ -49,8 +49,8 @@ def tutor_scaffold(tutor_root: Path) -> dict:
 def update_config(tutor_root: Path, settings: dict) -> None:
     """Update the Tutor environment with the given new settings."""
     current = get_current(tutor_root)
-    merge(settings, current)
-    save_config_file(tutor_root, current)
+    merge(settings, current, force=True)
+    save_config_file(tutor_root, settings)
 
 
 def template_source(template_relpath: Path) -> Path:

--- a/tutor_recon/util/misc.py
+++ b/tutor_recon/util/misc.py
@@ -35,7 +35,7 @@ def walk_dict(
 def set_nested(mapping: Mapping, key_sequence: "Sequence[str]", value: Any) -> None:
     """Set the value in `mapping` under the given sequence of nested keys.
 
-    Sub-mappings are created as instances of the same type as `mapping` if they do not yet exist.
+    Sub-mappings are created as instances of `dict` if they do not yet exist.
     """
     assert key_sequence, "The sequence of keys cannot be empty."
     if len(key_sequence) == 1:
@@ -43,7 +43,7 @@ def set_nested(mapping: Mapping, key_sequence: "Sequence[str]", value: Any) -> N
     else:
         first, rest = key_sequence[0], key_sequence[1:]
         if first not in mapping:
-            mapping[first] = type(mapping)()
+            mapping[first] = dict()
         set_nested(mapping[first], rest, value)
 
 

--- a/tutor_recon/util/vjson.py
+++ b/tutor_recon/util/vjson.py
@@ -7,7 +7,7 @@ from collections import MutableMapping
 from typing import Literal, Optional, Union
 from pathlib import Path
 
-from tutor_recon.util.misc import WrappedDict, brief
+from tutor_recon.util.misc import WrappedDict, brief, set_nested, walk_dict
 
 MARKER = "$"
 
@@ -98,6 +98,17 @@ class RemoteMapping(WrappedDict):
             json.dump(self._dict, f, cls=serializer, indent=4)
             if write_trailing_newline:
                 f.write("\n")
+
+
+def expand_mappings(mapping: MutableMapping) -> dict:
+    """Recursively expand any remote mappings within `mapping`."""
+    ret = dict()
+    for keys, val in walk_dict(mapping):
+        if isinstance(val, RemoteMapping):
+            set_nested(ret, keys, val.expand())
+        else:
+            set_nested(ret, keys, val)
+    return ret
 
 
 class VJSONDecoder(JSONDecoder):


### PR DESCRIPTION
This PR includes a re-work of the notion of "scaffolding" a Tutor template or setting. 

The process involves first copying the existing configuration to the `env_overrides` directory or providing all possible values for a configuration as "unset" defaults, depending on the type of override.

This separates the initialization process from the `save` method in objects which implement `OverrideMixin`. As a result, the set of possible types of files and settings that can be overridden is greatly expanded.

A bug with initialization was also fixed as a result of this change.