### PR TITLE
Dev Script Overhaul

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -4,13 +4,216 @@
 import subprocess
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
+from functools import wraps
 
 import click
 import cloup
 
+## CONSTANTS ##
+
+MAIN_BRANCH = "main"
+DEV_BRANCH = "dev"
 PROGRAM_STYLED = click.style("dev.py", fg="green")
+HELP_EXAMPLE = PROGRAM_STYLED + click.style(" COMMAND --help", fg="yellow")
+PROJECT_STYLED = click.style("tutor-contrib-recon", fg="magenta")
+PROGRAM_DESCRIPTION = f"""
+Development tools for {PROJECT_STYLED}.
+
+Use {HELP_EXAMPLE} for help with a particular subcommand."
+"""
 PROGRAM_TAG = f"[{PROGRAM_STYLED}]"
+CONTEXT_SETTINGS = cloup.Context.settings(
+    show_default=True,
+    formatter_settings=cloup.HelpFormatter.settings(
+        max_width=160,
+        theme=cloup.HelpTheme(
+            heading=cloup.Style(bold=True),
+            invoked_command=cloup.Style(fg=cloup.Color.green),
+            col1=cloup.Style(fg=cloup.Color.yellow),
+        ),
+        col2_min_width=99999,  # Force a linear layout.
+    ),
+)
+
+## OPTION GROUPS ##
+
+version_and_tag_options = cloup.option_group(
+    "Version & Tag Options",
+    cloup.option(
+        "--bump",
+        help="Increment the version number prior to committing.",
+        metavar="RULE",
+        type=cloup.Choice(
+            [
+                "major",
+                "minor",
+                "patch",
+                "premajor",
+                "preminor",
+                "prepatch",
+                "prerelease",
+            ]
+        ),
+    ),
+    cloup.option(
+        "--tag/--no-tag",
+        default=False,
+        help="Create a new tag with (updated) version. Off by default.",
+    ),
+    cloup.option(
+        "--tag-message",
+        help="The message to include in the new tag. Applies only when --tag is used.",
+        metavar="MESSAGE",
+    ),
+    cloup.option(
+        "--push-tag/--no-push-tag",
+        default=True,
+        help="Push the tag to the remote. On by default; applies only when --tag is used.",
+    ),
+)
+
+commit_options = cloup.option_group(
+    "Commit",
+    cloup.option("--commit/--no-commit", help="Create a new commit.", default=True),
+    cloup.option(
+        "-m", "--message", help="The commit message to use.", metavar="MESSAGE"
+    ),
+    cloup.option(
+        "--files",
+        "--paths",
+        type=list,
+        help="The files and/or directories to add prior to committing.",
+        default=["."],
+        metavar="PATHS",
+    ),
+)
+
+push_options = cloup.option_group(
+    "Push",
+    cloup.option(
+        "--push/--no-push", default=True, help="Push to the remote repository."
+    ),
+    cloup.option(
+        "--set-upstream/--no-set-upstream",
+        default=True,
+        help="Automatically add the current branch by name to the remote.",
+    ),
+)
+
+code_style_options = cloup.option_group(
+    "Code Style",
+    cloup.option(
+        "--black/--no-black",
+        default=True,
+        help="Run 'black' on all sources prior to committing.",
+    ),
+)
+
+
+## OPTION GROUP HANDLERS ##
+
+
+def handle_release_and_tag(opts: "dict[str, Any]") -> None:
+    bump, tag, push_tag, tag_message = map(
+        opts.pop, ("bump", "tag", "push_tag", "tag_message")
+    )
+    if bump:
+        bump_version(bump)
+        git_add("pyproject.toml")
+        git_commit(f"[dev bot] Bump to {get_version()}.")
+    if tag:
+        new_tag = git_tag(tag_message)
+        if push_tag:
+            git_push(new_tag)
+
+
+def handle_push(opts: "dict[str, Any]") -> None:
+    push, set_upstream = map(opts.pop, ("push", "set_upstream"))
+    if push:
+        git_push(set_upstream=set_upstream)
+
+
+def handle_black(opts: "dict[str, Any]") -> None:
+    black = opts.pop("black")
+    if black:
+        run_black()
+
+
+def handle_commit(opts: "dict[str, Any]") -> None:
+    commit, message, files = map(opts.pop, ("commit", "message", "files"))
+    if not files:
+        files = ["."]
+    if commit:
+        git_add(files)
+        git_commit(message)
+
+
+## DECORATORS ##
+
+
+def assert_all_options_handled(func):
+    """Decorate a function which must entirely consume its keyword arguments.
+
+    The keyword arguments are passed via a single named parameter `opts`. Any
+    positional arguments are passed on without modification.
+    """
+
+    @wraps(func)
+    def dec(*args, **kwargs) -> Any:
+        func(*args, opts=kwargs)
+        assert (
+            not kwargs
+        ), f"Some keyword arguments were not consumed by {func.__name__}: {kwargs.keys()}"
+
+    return dec
+
+
+## COMMANDS ##
+
+
+@cloup.group(context_settings=CONTEXT_SETTINGS, help=PROGRAM_DESCRIPTION)
+def dev():
+    """The main command group."""
+
+
+@dev.command()
+@commit_options
+@push_options
+@code_style_options
+@version_and_tag_options
+@assert_all_options_handled
+def publish(opts) -> None:
+    """Check your changes into version control. Also formats your code and pushes it to the configured remote by default."""
+    handle_black(opts)
+    handle_release_and_tag(opts)
+    handle_commit(opts)
+    handle_push(opts)
+
+
+@dev.command()
+@push_options
+@cloup.argument("branch_name", nargs=1, metavar="NAME")
+@assert_all_options_handled
+def new_feature(name: str, opts) -> None:
+    """Create a new feature branch based on origin/dev."""
+    ensure_on_branch(DEV_BRANCH)
+    git_checkout(name, new=True)
+    git_fetch("dev")
+    git_rebase("dev", remote=True)
+    handle_push(opts)
+
+
+@dev.command()
+@version_and_tag_options
+@assert_all_options_handled
+def merge_feature(opts) -> None:
+    """Merge the current feature branch into dev."""
+    merge_feature_to_dev()
+    handle_release_and_tag(opts)
+
+
+## UTILITIES ##
 
 
 class CommandFailure(Exception):
@@ -35,19 +238,29 @@ def error_exit(return_code: int = 1, message: str = "") -> None:
     sys.exit(return_code)
 
 
-def run(arg_list: "list[str]", error_on_fail: bool = True, *args, **kwargs) -> None:
+def run(
+    arg_list: "list[str]",
+    error_on_fail: bool = True,
+    echo: bool = True,
+    *args,
+    **kwargs,
+) -> None:
     """Run the command specified in `arg_list` with `subprocess.run` after first echoing it over stdout.
 
     *args and **kwargs are passed to `subprocess.run`.
     """
-    cmd_str = click.style(" ".join(arg_list), fg="yellow")
-    emit(f"Running: {cmd_str}")
+    if echo:
+        cmd_str = click.style(" ".join(arg_list), fg="yellow")
+        emit(f"Running: {cmd_str}")
     completed_process = subprocess.run(arg_list, *args, **kwargs)
     if error_on_fail and completed_process.returncode:
         raise CommandFailure(
             completed_process.returncode, f"Command {arg_list} failed."
         )
     return completed_process
+
+
+## MISC HELPER FUNCTIONS ##
 
 
 def run_black() -> None:
@@ -73,7 +286,10 @@ def bump_and_commit(rule: str) -> None:
     emit(f"Bumping the {rule} version.")
     bump_version(rule)
     git_add("pyproject.toml")
-    git_commit(f"[dev bot] Bump to version '{get_version()}'.")
+    git_commit(f"[dev bot] Bump to v{get_version()}.")
+
+
+## GIT HELPER FUNCTIONS ##
 
 
 def git_add(files: "list[str]") -> None:
@@ -87,18 +303,34 @@ def git_commit(message: str = "") -> None:
     run(cmd)
 
 
-def git_push(*args) -> None:
-    push_cmd = ["git", "push"]
-    push_cmd += args
-    run(push_cmd)
+def git_push(
+    id: Optional[str] = None, set_upstream: bool = False, remote_name="origin"
+) -> None:
+    if id is None:
+        id = get_git_branch()
+    cmd = ["git", "push"]
+    if set_upstream:
+        cmd += ["--set-upstream"]
+    cmd += [remote_name, id]
+    run(cmd)
 
 
 def git_fetch(branch_name: str, remote_name: str = "origin") -> None:
     run(["git", "fetch", remote_name, branch_name])
 
 
-def git_rebase(branch_name: str) -> None:
-    run(["git", "rebase", branch_name])
+def git_rebase(
+    branch_name: str, remote: bool = False, remote_name: str = "origin"
+) -> None:
+    """Rebase the current branch onto `branch_name`.
+
+    `branch_name` is assumed to be a local branch unless `remote` is set to `True`.
+    """
+    cmd = ["git", "rebase"]
+    if remote:
+        cmd += remote_name
+    cmd += branch_name
+    run(cmd)
 
 
 def git_tag(message: str = "") -> str:
@@ -133,7 +365,10 @@ def git_merge(*args) -> None:
 
 def get_git_branch() -> str:
     return run(
-        ["git", "symbolic-ref", "--short", "HEAD"], capture_output=True, text=True
+        ["git", "symbolic-ref", "--short", "HEAD"],
+        echo=False,
+        capture_output=True,
+        text=True,
     ).stdout.strip()
 
 
@@ -148,162 +383,50 @@ def ensure_on_branch(branch_name: str) -> str:
 
 
 def ensure_not_on_branches(*branch_names: str) -> str:
-    """Exit with an error if on one of the given branches; return the current branch's name."""
+    """Exit with an error if on one of the given branches; return the current branch's name otherwise."""
     current = get_git_branch()
     if current in branch_names:
         error_exit(f"This action cannot be performed from branch {current}.")
     return current
 
 
-def prep_pr(bump_rule: str = ""):
-    """Rebase the current branch off of dev, optionally increment the version, then checkout dev and merge the feature branch."""
-    git_fetch("dev")
-    feature_branch = ensure_not_on_branches("main", "dev")
+def merge_feature_to_dev():
+    """Rebase the current feature branch off of dev then checkout dev and merge the feature branch."""
+    git_fetch(DEV_BRANCH)
+    feature_branch = ensure_not_on_branches(MAIN_BRANCH, DEV_BRANCH)
     emit(f"Rebasing {feature_branch} onto dev.")
-    git_rebase("dev")
-    if bump_rule:
-        bump_and_commit(bump_rule)
+    git_rebase(DEV_BRANCH)
     emit("Checking out dev.")
-    git_checkout("dev")
+    git_checkout(DEV_BRANCH)
     emit(
         f"Squashing and merging {feature_branch} into dev. Please describe the change in the text editor that appears."
     )
     git_merge("--squash", feature_branch)
-    emit(f"Finished merge. Deleting {feature_branch}.")
-    git_branch("-d", feature_branch)
+    emit(f"Finished merge.")
+    git_add(".")
     git_commit(f"Squash and merge {feature_branch} into dev.")
-    git_push()
-    emit(f"Congratulations! You're ready to create a PR from dev into main.")
+    emit(f"Created commit.")
+    push_cmd = click.style(f"git push", fg="yellow")
+    delete_cmd = click.style(f"git branch -d {feature_branch}", fg="yellow")
+    emit(
+        f"Congratulations! You're almost ready to create a PR from {DEV_BRANCH} into {MAIN_BRANCH}."
+    )
+    emit(f"You will need to run {push_cmd}.")
+    emit("Once finished, you're ready to create a pull request via GitHub 🎉🎉")
+    emit(f"Use {delete_cmd} to remove the old feature branch locally.")
 
 
-def release():
-    """Rebase dev onto main, then replace main with dev."""
-    git_fetch("main")
-    git_rebase("main")
-    git_push("origin", "dev:main")
+def release_no_merge():
+    """Rebase dev onto main, then replace main with dev.
+
+    NOTE: Planned for future use. Function can be called manually via interactive shell if needed for now.
+    """
+    git_fetch(MAIN_BRANCH)
+    git_rebase(MAIN_BRANCH)
+    git_push(f"{DEV_BRANCH}:{MAIN_BRANCH}")
 
 
-@cloup.group()
-def dev():
-    """Development tools for tutor-contrib-recon."""
-
-
-@dev.command()
-@cloup.option_group(
-    "Commit",
-    cloup.option("--commit/--no-commit", help="Create a new commit.", default=True),
-    cloup.option(
-        "-m", "--message", help="The commit message to use.", metavar="MESSAGE"
-    ),
-)
-@cloup.option_group(
-    "Push",
-    cloup.option(
-        "--push/--no-push", default=True, help="Push to the remote after committing."
-    ),
-    cloup.option(
-        "--set-upstream/--no-set-upstream",
-        default=True,
-        help="Automatically add the current branch by name to the remote.",
-    ),
-)
-@cloup.option(
-    "--black/--no-black",
-    default=True,
-    help="Run 'black' on all sources prior to committing.",
-)
-@cloup.option_group(
-    "Release",
-    cloup.option(
-        "--bump",
-        default="",
-        help="Increment the version number prior to committing.",
-        metavar="RULE",
-        type=cloup.Choice(
-            [
-                "",
-                "major",
-                "minor",
-                "patch",
-                "premajor",
-                "preminor",
-                "prepatch",
-                "prerelease",
-            ]
-        ),
-    ),
-    cloup.option(
-        "--tag/--no-tag",
-        default=False,
-        help="Create a new tag with (updated) version. Off by default.",
-    ),
-    cloup.option(
-        "--push-tag/--no-push-tag",
-        default=True,
-        help="Push the tag to the remote. On by default; applies only when --tag is used.",
-    ),
-    cloup.option(
-        "--tag-message",
-        default="",
-        help="The message to include in the new tag. Applies only when --tag is used.",
-        metavar="TAG_MESSAGE",
-    ),
-)
-@cloup.argument("files", nargs=-1)
-def publish(
-    commit: bool,
-    message: str,
-    push: bool,
-    set_upstream: bool,
-    black: bool,
-    bump: str,
-    tag: bool,
-    push_tag: bool,
-    tag_message: str,
-    files: "list[str]",
-) -> None:
-    """Check your changes into version control. Also formats your code and pushes it to the configured remote by default."""
-    if files:
-        files = [str(Path(f).resolve()) for f in files]
-    else:
-        files = [str(Path(".").resolve())]
-    if black:
-        run_black()
-    if bump:
-        bump_version(bump)
-        toml_file = str(Path("pyproject.toml").resolve())
-        if toml_file not in files:
-            files.append(toml_file)
-        if not message:
-            message = f"[dev bot] Bump to version '{get_version()}'."
-    if commit:
-        git_add(files)
-        git_commit(message)
-    if tag:
-        new_tag = git_tag(tag_message)
-        if push_tag:
-            git_push("origin", new_tag)
-    if push:
-        push_args = []
-        if set_upstream:
-            push_args += ["--set-upstream", "origin", get_git_branch()]
-        git_push(*push_args)
-
-
-@dev.command()
-@cloup.argument("name", nargs=1)
-def newfeature(name) -> None:
-    """Create a new feature branch."""
-    ensure_on_branch("dev")
-    git_checkout(name, new=True)
-
-
-@dev.command()
-def prep_feature_pr() -> None:
-    """Prepare the current feature branch for a PR by running black and rebasing onto dev."""
-    ensure_not_on_branches("main", "dev")
-    prep_pr("")
-
+## STARTUP LOGIC ##
 
 if __name__ == "__main__":
     try:
@@ -311,5 +434,6 @@ if __name__ == "__main__":
     except CommandFailure as e:
         error_exit(e.return_code, e.message)
     except SystemExit:
+        # Don't propagate click's automatic SystemExit if running interactively.
         if not getattr(sys, "ps1", sys.flags.interactive):
-            raise  # Don't propagate if running interactively.
+            raise


### PR DESCRIPTION
This PR attempts to make the dev script both more readable and more usable.

The script's functionality has not changed apart from the feature-branch workflow, which now leaves more of the process to the developer. When merging a feature to dev, rather than executing `git push` and deleting the old branch, the required commands are printed to the terminal for reference purposes.

The help text is now more readable, especially the option defaults, and it is now colorful.

The script itself is significantly restructured to allow option group re-use.